### PR TITLE
Feature/8 find nearby parks

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -51,12 +51,12 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
     }
 
     kotlinOptions {
-        jvmTarget = "1.8"
+        jvmTarget = "11"
     }
 
     packaging {
@@ -120,6 +120,9 @@ dependencies {
     implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(platform(libs.compose.bom))
     testImplementation(libs.junit)
+    testImplementation(libs.mockito.core)
+    testImplementation(libs.mockito.inline)
+    testImplementation(libs.mockito.kotlin)
     globalTestImplementation(libs.androidx.junit)
     globalTestImplementation(libs.androidx.espresso.core)
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -69,8 +69,6 @@ android {
         unitTests {
             isIncludeAndroidResources = true
             isReturnDefaultValues = true
-
-
         }
 
     }
@@ -116,7 +114,7 @@ fun DependencyHandlerScope.globalTestImplementation(dep: Any) {
 }
 
 dependencies {
-    testImplementation("org.json:json:20160810")
+    testImplementation(libs.json)
     implementation(libs.okhttp)
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.appcompat)

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -113,6 +113,7 @@ fun DependencyHandlerScope.globalTestImplementation(dep: Any) {
 }
 
 dependencies {
+    implementation(libs.okhttp)
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.appcompat)
     implementation(libs.material)

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -69,7 +69,10 @@ android {
         unitTests {
             isIncludeAndroidResources = true
             isReturnDefaultValues = true
+
+
         }
+
     }
 
     // Robolectric needs to be run only in debug. But its tests are placed in the shared source set (test)
@@ -113,6 +116,7 @@ fun DependencyHandlerScope.globalTestImplementation(dep: Any) {
 }
 
 dependencies {
+    testImplementation("org.json:json:20160810")
     implementation(libs.okhttp)
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.appcompat)
@@ -125,6 +129,7 @@ dependencies {
     testImplementation(libs.mockito.kotlin)
     globalTestImplementation(libs.androidx.junit)
     globalTestImplementation(libs.androidx.espresso.core)
+
 
     // ------------- Jetpack Compose ------------------
     val composeBom = platform(libs.compose.bom)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <uses-permission android:name="android.permission.INTERNET" />
     <application
         android:usesCleartextTraffic="false"
         android:allowBackup="true"

--- a/app/src/main/java/com/android/streetworkapp/model/parks/OverpassParkLocationRepository.kt
+++ b/app/src/main/java/com/android/streetworkapp/model/parks/OverpassParkLocationRepository.kt
@@ -1,0 +1,2 @@
+package com.android.streetworkapp.model.parks
+

--- a/app/src/main/java/com/android/streetworkapp/model/parks/OverpassParkLocationRepository.kt
+++ b/app/src/main/java/com/android/streetworkapp/model/parks/OverpassParkLocationRepository.kt
@@ -3,6 +3,7 @@ package com.android.streetworkapp.model.parks
 import java.io.IOException
 import okhttp3.Call
 import okhttp3.Callback
+import okhttp3.HttpUrl
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.Response
@@ -28,12 +29,19 @@ class OverpassParkLocationRepository(private val client: OkHttpClient) : ParkLoc
     }
 
     // Based on the Overpass API. More information: https://wiki.openstreetmap.org/wiki/Overpass_API
-    val request =
-        Request.Builder()
-            .url(
-                "https://overpass-api.de/api/interpreter?data=[out:json];way[%22leisure%22=%22fitness_station%22](around:30000,$lat,$lon);%20out%20geom%20center;")
-            .header("User-Agent", "test/5.0")
+
+    val url =
+        HttpUrl.Builder()
+            .scheme("https")
+            .host("overpass-api.de")
+            .addPathSegment("api")
+            .addPathSegment("interpreter")
+            .addEncodedQueryParameter(
+                "data",
+                "[out:json];way[\"leisure\"=\"fitness_station\"](around:30000,$lat,$lon);%20out%20geom%20center;")
             .build()
+
+    val request = Request.Builder().url(url).header("User-Agent", "test/5.0").build()
     client
         .newCall(request)
         .enqueue(
@@ -53,6 +61,7 @@ fun decodeJson(json: String): List<ParkLocation> {
   if (json.isEmpty()) {
     throw IllegalArgumentException()
   }
+
   val jsonObject = JSONObject(json)
   val elementsArray = jsonObject.getJSONArray("elements")
 

--- a/app/src/main/java/com/android/streetworkapp/model/parks/OverpassParkLocationRepository.kt
+++ b/app/src/main/java/com/android/streetworkapp/model/parks/OverpassParkLocationRepository.kt
@@ -1,2 +1,73 @@
 package com.android.streetworkapp.model.parks
 
+import java.io.IOException
+import okhttp3.Call
+import okhttp3.Callback
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.Response
+import org.json.JSONObject
+
+class OverpassParkLocationRepository(private val client: OkHttpClient) : ParkLocationRepository {
+  /**
+   * Find all nearby Street Workout parks, from OpenStreetMap using Overpass API
+   *
+   * @param lat : latitude (Double)
+   * @param lon : longitude (Double)
+   * @param onSuccess : to handle successful cases
+   * @param onFailure : to handle unsuccessful cases
+   */
+  override fun search(
+      lat: Double,
+      lon: Double,
+      onSuccess: (List<ParkLocation>) -> Unit,
+      onFailure: (Exception) -> Unit
+  ) {
+    // Based on the Overpass API. More information: https://wiki.openstreetmap.org/wiki/Overpass_API
+    val request =
+        Request.Builder()
+            .url(
+                "https://overpass-api.de/api/interpreter?data=[out:json];way[%22leisure%22=%22fitness_station%22](around:30000,$lat,$lon);%20out%20geom%20center;")
+            .header("User-Agent", "test/5.0")
+            .build()
+    client
+        .newCall(request)
+        .enqueue(
+            object : Callback {
+              override fun onFailure(call: Call, e: IOException) {
+                e.printStackTrace()
+              }
+
+              override fun onResponse(call: Call, response: Response) {
+                response.use {
+                  if (!response.isSuccessful) {
+                    throw IOException("Unexpected code $response")
+                  }
+                  val listLocation = decodeJson(response.body!!.string())
+                  onSuccess(listLocation)
+                }
+              }
+            })
+  }
+}
+
+private fun decodeJson(json: String): List<ParkLocation> {
+  val jsonObject = JSONObject(json)
+  val elementsArray = jsonObject.getJSONArray("elements")
+
+  val listParkLocation = emptyList<ParkLocation>().toMutableList()
+
+  for (i in 0 until elementsArray.length()) {
+    val element = elementsArray.getJSONObject(i)
+    val center = element.getJSONObject("center")
+
+    val latitude = center.getDouble("lat")
+    val longitude = center.getDouble("lon")
+    val id = element.getString("id")
+
+    val parkLocation = ParkLocation(latitude, longitude, id)
+
+    listParkLocation += parkLocation
+  }
+  return listParkLocation
+}

--- a/app/src/main/java/com/android/streetworkapp/model/parks/OverpassParkLocationRepository.kt
+++ b/app/src/main/java/com/android/streetworkapp/model/parks/OverpassParkLocationRepository.kt
@@ -24,9 +24,8 @@ class OverpassParkLocationRepository(private val client: OkHttpClient) : ParkLoc
       onSuccess: (List<ParkLocation>) -> Unit,
       onFailure: (Exception) -> Unit
   ) {
-    if (lat > 90 || lat < -90 || lon > 180 || lon < -180) {
-      throw IllegalArgumentException()
-    }
+    require(lat < 90 && lat > -90)
+    require(lon < 180 && lon > -180)
 
     // Based on the Overpass API. More information: https://wiki.openstreetmap.org/wiki/Overpass_API
 
@@ -57,15 +56,18 @@ class OverpassParkLocationRepository(private val client: OkHttpClient) : ParkLoc
   }
 }
 
+/**
+ * Decodes JSON coming from the Overpass API.
+ *
+ * @param json : A string with the JSON format. It can not be empty.
+ */
 fun decodeJson(json: String): List<ParkLocation> {
-  if (json.isEmpty()) {
-    throw IllegalArgumentException()
-  }
+  require(json.isNotEmpty())
 
   val jsonObject = JSONObject(json)
   val elementsArray = jsonObject.getJSONArray("elements")
 
-  val listParkLocation = emptyList<ParkLocation>().toMutableList()
+  val listParkLocation = mutableListOf<ParkLocation>()
 
   for (i in 0 until elementsArray.length()) {
 

--- a/app/src/main/java/com/android/streetworkapp/model/parks/OverpassParkLocationRepository.kt
+++ b/app/src/main/java/com/android/streetworkapp/model/parks/OverpassParkLocationRepository.kt
@@ -50,6 +50,9 @@ class OverpassParkLocationRepository(private val client: OkHttpClient) : ParkLoc
 }
 
 fun decodeJson(json: String): List<ParkLocation> {
+  if (json.isEmpty()) {
+    throw IllegalArgumentException()
+  }
   val jsonObject = JSONObject(json)
   val elementsArray = jsonObject.getJSONArray("elements")
 

--- a/app/src/main/java/com/android/streetworkapp/model/parks/ParkLocation.kt
+++ b/app/src/main/java/com/android/streetworkapp/model/parks/ParkLocation.kt
@@ -1,0 +1,3 @@
+package com.android.streetworkapp.model.parks
+
+data class ParkLocation (val lat: Double,val lon: Double,val id: String)

--- a/app/src/main/java/com/android/streetworkapp/model/parks/ParkLocation.kt
+++ b/app/src/main/java/com/android/streetworkapp/model/parks/ParkLocation.kt
@@ -1,3 +1,3 @@
 package com.android.streetworkapp.model.parks
 
-data class ParkLocation (val lat: Double,val lon: Double,val id: String)
+data class ParkLocation(val lat: Double, val lon: Double, val id: String)

--- a/app/src/main/java/com/android/streetworkapp/model/parks/ParkLocationRepository.kt
+++ b/app/src/main/java/com/android/streetworkapp/model/parks/ParkLocationRepository.kt
@@ -1,5 +1,6 @@
 package com.android.streetworkapp.model.parks
 
+/** A repository interface for searching nearby park locations. */
 interface ParkLocationRepository {
   fun search(
       lat: Double,

--- a/app/src/main/java/com/android/streetworkapp/model/parks/ParkLocationRepository.kt
+++ b/app/src/main/java/com/android/streetworkapp/model/parks/ParkLocationRepository.kt
@@ -1,0 +1,10 @@
+package com.android.streetworkapp.model.parks
+
+interface ParkLocationRepository {
+  fun search(
+      lat: Double,
+      lon: Double,
+      onSuccess: (List<ParkLocation>) -> Unit,
+      onFailure: (Exception) -> Unit
+  )
+}

--- a/app/src/main/java/com/android/streetworkapp/model/parks/ParkLocationViewModel.kt
+++ b/app/src/main/java/com/android/streetworkapp/model/parks/ParkLocationViewModel.kt
@@ -17,9 +17,8 @@ class ParkLocationViewModel(private val repository: ParkLocationRepository) : Vi
    * @param lon : Longitude (Double) must be between [-180,180]
    */
   fun findNearbyParks(lat: Double, lon: Double) {
-    if (lat > 90 || lat < -90 || lon > 180 || lon < -180) {
-      throw IllegalArgumentException()
-    }
+    require(lat < 90 && lat > -90)
+    require(lon < 180 && lon > -180)
 
     repository.search(lat, lon, { parkLocations -> parksPrivate.value = parkLocations }, {})
   }

--- a/app/src/main/java/com/android/streetworkapp/model/parks/ParkLocationViewModel.kt
+++ b/app/src/main/java/com/android/streetworkapp/model/parks/ParkLocationViewModel.kt
@@ -1,0 +1,22 @@
+package com.android.streetworkapp.model.parks
+
+import androidx.lifecycle.ViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+class ParkLocationViewModel(private val repository: ParkLocationRepository) : ViewModel() {
+
+  private val parksPrivate = MutableStateFlow<List<ParkLocation>>(emptyList())
+  val parks: StateFlow<List<ParkLocation>> = parksPrivate.asStateFlow()
+
+  /**
+   * Find Street Workout parks that are close to a given latitude and longitude
+   *
+   * @param lat : Latitude (Double)
+   * @param lon : Longitude (Double)
+   */
+  fun findNearbyParks(lat: Double, lon: Double) {
+    repository.search(lat, lon, { parkLocations -> parksPrivate.value = parkLocations }, {})
+  }
+}

--- a/app/src/main/java/com/android/streetworkapp/model/parks/ParkLocationViewModel.kt
+++ b/app/src/main/java/com/android/streetworkapp/model/parks/ParkLocationViewModel.kt
@@ -13,10 +13,14 @@ class ParkLocationViewModel(private val repository: ParkLocationRepository) : Vi
   /**
    * Find Street Workout parks that are close to a given latitude and longitude
    *
-   * @param lat : Latitude (Double)
-   * @param lon : Longitude (Double)
+   * @param lat : Latitude (Double) must be between [-90,90]
+   * @param lon : Longitude (Double) must be between [-180,180]
    */
   fun findNearbyParks(lat: Double, lon: Double) {
+    if (lat > 90 || lat < -90 || lon > 180 || lon < -180) {
+      throw IllegalArgumentException()
+    }
+
     repository.search(lat, lon, { parkLocations -> parksPrivate.value = parkLocations }, {})
   }
 }

--- a/app/src/test/java/com/android/streetworkapp/model/parks/OverpassParkLocationRepositoryTest.kt
+++ b/app/src/test/java/com/android/streetworkapp/model/parks/OverpassParkLocationRepositoryTest.kt
@@ -40,6 +40,12 @@ class OverpassParkLocationRepositoryTest {
     assert(test.isEmpty())
   }
 
+  @Test(expected = IllegalArgumentException::class)
+  fun decodeJSONThrowsOnEmptyString() {
+    val string = ""
+    val test = decodeJson(string)
+  }
+
   @Test
   fun searchCallsNewCall() {
     val overpass = OverpassParkLocationRepository(okHttpClient)

--- a/app/src/test/java/com/android/streetworkapp/model/parks/OverpassParkLocationRepositoryTest.kt
+++ b/app/src/test/java/com/android/streetworkapp/model/parks/OverpassParkLocationRepositoryTest.kt
@@ -1,0 +1,55 @@
+package com.android.streetworkapp.model.parks
+
+import okhttp3.Call
+import okhttp3.OkHttpClient
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
+import org.mockito.kotlin.any
+
+class OverpassParkLocationRepositoryTest {
+  private lateinit var okHttpClient: OkHttpClient
+  private lateinit var call: Call
+
+  @Before
+  fun setUp() {
+    okHttpClient = mock(OkHttpClient::class.java)
+    call = mock(Call::class.java)
+
+    `when`(okHttpClient.newCall(any())).thenReturn(call)
+  }
+
+  @Test
+  fun decodeJSONWorksOnKnownString() {
+    val string =
+        "{\"version\":0.6,\"generator\":\"Overpass API 0.7.62.1 084b4234\",\"osm3s\":{\"timestamp_osm_base\":\"2024-10-06T17:27:57Z\",\"copyright\":\"The data included in this document is from www.openstreetmap.org. The data is made available under ODbL.\"},\"elements\":[{\"type\":\"way\",\"id\":682145783,\"center\":{\"lat\":46.5228885,\"lon\":6.6252872},\"nodes\":[6388088374,6388088373,6388088372,6388088371,6388088374],\"tags\":{\"image\":\"https://commons.wikimedia.org/wiki/Category:Kenguru.Pro#/media/File:Lausanne-KenguruPro.jpg\",\"layer\":\"-1\",\"leisure\":\"fitness_station\",\"sport\":\"exercise\"}}]}"
+    val listParks = decodeJson(string)
+    assert(listParks.isNotEmpty())
+    assert(listParks[0].lat == 46.5228885)
+    assert(listParks[0].lon == 6.6252872)
+    assert(listParks[0].id == "682145783")
+  }
+
+  @Test
+  fun decodeJSONWorksOnKnownStringWithNoElement() {
+    val string =
+        "{\"version\":0.6,\"generator\":\"Overpass API 0.7.62.1 084b4234\",\"osm3s\":{\"timestamp_osm_base\":\"2024-10-06T17:50:30Z\",\"copyright\":\"The data included in this document is from www.openstreetmap.org. The data is made available under ODbL.\"},\"elements\":[]}"
+    val test = decodeJson(string)
+    assert(test.isEmpty())
+  }
+
+  @Test
+  fun searchCallsNewCall() {
+    val overpass = OverpassParkLocationRepository(okHttpClient)
+    overpass.search(0.0, 0.0, {}, {})
+    verify(okHttpClient).newCall(any())
+  }
+
+  @Test(expected = IllegalArgumentException::class)
+  fun searchThrowsOnInvalidLatAndLon() {
+    val overpass = OverpassParkLocationRepository(okHttpClient)
+    overpass.search(-200.0, -200.0, {}, {})
+  }
+}

--- a/app/src/test/java/com/android/streetworkapp/model/parks/ParkLocationViewModelTest.kt
+++ b/app/src/test/java/com/android/streetworkapp/model/parks/ParkLocationViewModelTest.kt
@@ -1,0 +1,25 @@
+package com.android.streetworkapp.model.parks
+
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.verify
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+
+class ParkLocationViewModelTest {
+  private lateinit var parkLocationRepository: ParkLocationRepository
+  private lateinit var parkLocationViewModel: ParkLocationViewModel
+
+  @Before
+  fun setUp() {
+    parkLocationRepository = mock(ParkLocationRepository::class.java)
+    parkLocationViewModel = ParkLocationViewModel(parkLocationRepository)
+  }
+
+  @Test
+  fun findNearbyParksCallsRepository() {
+    parkLocationViewModel.findNearbyParks(0.0, 0.0)
+    verify(parkLocationRepository).search(eq(0.0), eq(0.0), any(), any())
+  }
+}

--- a/app/src/test/java/com/android/streetworkapp/model/parks/ParkLocationViewModelTest.kt
+++ b/app/src/test/java/com/android/streetworkapp/model/parks/ParkLocationViewModelTest.kt
@@ -20,6 +20,12 @@ class ParkLocationViewModelTest {
   @Test
   fun findNearbyParksCallsRepository() {
     parkLocationViewModel.findNearbyParks(0.0, 0.0)
+    assert(parkLocationViewModel.parks.value.isEmpty())
     verify(parkLocationRepository).search(eq(0.0), eq(0.0), any(), any())
+  }
+
+  @Test(expected = IllegalArgumentException::class)
+  fun findNearbyParksThrowsOnInvalidLatAndLon() {
+    parkLocationViewModel.findNearbyParks(-200.0, -200.0)
   }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,6 +15,7 @@ lifecycleRuntimeKtx = "2.7.0"
 kaspresso = "1.5.5"
 robolectric = "4.11.1"
 sonar = "4.4.1.3373"
+okhttp = "4.12.0"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -27,6 +28,7 @@ androidx-lifecycle-runtime-ktx = { group = "androidx.lifecycle", name = "lifecyc
 
 compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "composeBom" }
 compose-material3 = { group = "androidx.compose.material3", name = "material3" }
+okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }
 compose-ui = { group = "androidx.compose.ui", name = "ui" }
 compose-ui-graphics = { group = "androidx.compose.ui", name = "ui-graphics" }
 compose-preview = { group = "androidx.compose.ui", name = "ui-tooling-preview" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,6 @@
 [versions]
 agp = "8.3.0"
+json = "20240303"
 kotlin = "1.8.10"
 coreKtx = "1.12.0"
 ktfmt = "0.17.0"
@@ -23,6 +24,7 @@ mockitoKotlin = "5.4.0"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
+json = { module = "org.json:json", version.ref = "json" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }
 androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espressoCore" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,6 +17,10 @@ robolectric = "4.11.1"
 sonar = "4.4.1.3373"
 okhttp = "4.12.0"
 
+mockitoCore = "3.12.4"
+mockitoInline = "3.12.4"
+mockitoKotlin = "5.4.0"
+
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
@@ -42,6 +46,11 @@ kaspresso = { group = "com.kaspersky.android-components", name = "kaspresso", ve
 kaspresso-compose = { group = "com.kaspersky.android-components", name = "kaspresso-compose-support", version.ref = "kaspresso" }
 
 robolectric = { module = "org.robolectric:robolectric", version.ref = "robolectric" }
+
+mockito-core = { module = "org.mockito:mockito-core", version.ref = "mockitoCore" }
+mockito-inline = { module = "org.mockito:mockito-inline", version.ref = "mockitoInline" }
+mockito-kotlin = { module = "org.mockito.kotlin:mockito-kotlin" , version.ref="mockitoKotlin"}
+
 
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
**Finding Nearby Street Workout Parks**

In order to be able to find the Street Workout parks, we need to fetch their location on OpenStreetMap. For this, there is an useful API called Overpass. (https://wiki.openstreetmap.org/wiki/Overpass_API)

This is a read-only API for OpenStreetMap that can be use to find all elements with a given tag in a given area. Based on this API, I propose a ViewModel that can be used later in the project to place the parks on the map. 



**How to test this feature?**

you can use this composable:
```
@Composable
fun TestFindNearbyParks() {
  val parkLocationViewModel = ParkLocationViewModel(OverpassParkLocationRepository(OkHttpClient()))
  Button(
      onClick = {
        parkLocationViewModel.findNearbyParks(46.5182803779489, 6.568465929047534) // EPFL location
        for (i in parkLocationViewModel.parks.value) {
          Log.d("test", "lat: " + i.lat + " lon: " + i.lon + " id: " + i.id)
        }
      }) {
        Text("Test Http")
      }
}
```
You should see a set of locations on the logs. You might need to push the button twice, since there is a delay between the click and the response of OpenStreetMap.

