### PR TITLE
Update the readme 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,26 @@
-[![SonarCloud Coverage](https://sonarcloud.io/api/project_badges/measure?project=SwEnt-Group8_Street-work-app&metric=coverage)](https://sonarcloud.io/summary/overall?id=SwEnt-Group8_Street-work-app)
+[![Dynamic JSON Badge](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fraw.githubusercontent.com%2FSwEnt-Group8%2Fcoverage-line-scrapper%2Frefs%2Fheads%2Fmain%2Fparsed-coverage.json&query=LineCoverage&logo=sonarcloud&label=Coverage%20line&color=0ca50c&link=https%3A%2F%2Fsonarcloud.io%2Fcomponent_measures%3Fmetric%3Dline_coverage%26view%3Dlist%26id%3DSwEnt-Group8_Street-work-app)](https://sonarcloud.io/component_measures?metric=line_coverage&view=list&id=SwEnt-Group8_Street-work-app)
 [![SonarCloud Bugs](https://sonarcloud.io/api/project_badges/measure?project=SwEnt-Group8_Street-work-app&metric=bugs)](https://sonarcloud.io/summary/overall?id=SwEnt-Group8_Street-work-app)
 [![SonarCloud Security](https://sonarcloud.io/api/project_badges/measure?project=SwEnt-Group8_Street-work-app&metric=security_rating)](https://sonarcloud.io/summary/overall?id=SwEnt-Group8_Street-work-app)
 [![SonarCloud Vulnerabilities](https://sonarcloud.io/api/project_badges/measure?project=SwEnt-Group8_Street-work-app&metric=vulnerabilities)](https://sonarcloud.io/summary/overall?id=SwEnt-Group8_Street-work-app)
+[![SonarCloud Reliability](https://sonarcloud.io/api/project_badges/measure?project=SwEnt-Group8_Street-work-app&metric=reliability_rating)](https://sonarcloud.io/summary/overall?id=SwEnt-Group8_Street-work-app)
 
 # The Street Work’App – Bringing Athletes Together
+
+## Links
+[Figma 🎨](https://www.figma.com/design/4mU3E7xxGna8ou16wqOwAO/Street-Work'App?node-id=0-1&t=1wSLdlQFebCPNyh4-1)
+
+## Team Members
+
+| Name                                | Github profile                              |
+|-------------------------------------|---------------------------------------------|
+| Alexandre Paul Auguste Norén Vaisse | [Alex720p](https://github.com/Alex720p)     |
+| Alvaro Julien Moya Mendez           | [alvaro1080](https://github.com/alvaro1080) |
+| Arthur Muster                       | [SaturneV](https://github.com/SaturneV)     |
+| Kemin Zheng                         | [kzepfl](https://github.com/kzepfl)         |
+| Malick Alexandre Kodjo Sy           | [misterM125](https://github.com/misterM125) |
+| Paul Tercier                        | [tercierp](https://github.com/tercierp)     |
+| Simon Schranz                       | [Simmanz](https://github.com/Simmanz)       |
+
 
 ## Overview
 The Street Work'App is designed to connect street workout enthusiasts by recommending parks for workouts and facilitating real-life social interactions. Street workout is a growing physical activity that combines calisthenics and gymnastics, performed in outdoor spaces like parks. This app helps users find like-minded individuals to practice with and promotes the development of a local street workout community.
@@ -43,7 +60,3 @@ The Street Work'App is designed to connect street workout enthusiasts by recomme
     - Users can view cached maps and workout plans even without an internet connection.
 
 The Street Work'App aims to not only provide workout locations but also to build lasting connections between street workout enthusiasts in their communities.
-
-
-# Figma
-https://www.figma.com/design/4mU3E7xxGna8ou16wqOwAO/Street-Work'App?node-id=0-1&t=1wSLdlQFebCPNyh4-1


### PR DESCRIPTION
The [document for milestone 1](https://github.com/swent-epfl/public/blob/main/project/M1.md) has been released, so we've switched to line coverage instead of coverage.

- Added dynamic JSON badge to display line coverage from a JSON file in the repository
- Included SonarCloud reliability rating badge to track project reliability
- Reformatted Figma link under a dedicated "Links" section for better readability
- Added team members section with GitHub profile links to acknowledge contributors

These updates enhance visibility of code quality metrics and improve overall documentation.