### PR TITLE
Feat/UI to create new events

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -139,6 +139,7 @@ fun DependencyHandlerScope.globalTestImplementation(dep: Any) {
 dependencies {
     implementation(libs.androidx.navigation.runtime.ktx)
     implementation(libs.androidx.navigation.compose)
+    implementation (libs.androidx.material.icons.extended)
     implementation(libs.androidx.navigation.testing)
     implementation(libs.androidx.navigation.compose)
     testImplementation(libs.json)

--- a/app/src/androidTest/java/com/android/streetworkapp/ui/parkoverview/AddEventTest.kt
+++ b/app/src/androidTest/java/com/android/streetworkapp/ui/parkoverview/AddEventTest.kt
@@ -5,8 +5,12 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performGesture
+import androidx.compose.ui.test.performTextClearance
+import androidx.compose.ui.test.performTextInput
 import androidx.compose.ui.test.swipeRight
 import com.android.streetworkapp.model.event.Event
+import com.android.streetworkapp.ui.park.EventDescriptionSelection
+import com.android.streetworkapp.ui.park.EventTitleSelection
 import com.android.streetworkapp.ui.park.ParticipantNumberSelection
 import com.android.streetworkapp.ui.park.TimeSelection
 import com.google.firebase.Timestamp
@@ -55,5 +59,25 @@ class AddEventTest {
     composeTestRule.onNodeWithTag("timeIcon").performClick()
     composeTestRule.onNodeWithTag("validateTime").performClick()
     assert(eventCopy.date != Timestamp(0, 0))
+  }
+
+  @Test
+  fun titleSelectionUpdatesEvent() {
+    val eventCopy = event.copy()
+    composeTestRule.setContent { EventTitleSelection(eventCopy) }
+    composeTestRule.onNodeWithTag("titleTag").performTextClearance()
+    composeTestRule.onNodeWithTag("titleTag").performTextInput("test")
+
+    assert(eventCopy.title == "test")
+  }
+
+  @Test
+  fun descriptionSelectionUpdatesEvent() {
+    val eventCopy = event.copy()
+    composeTestRule.setContent { EventDescriptionSelection(eventCopy) }
+    composeTestRule.onNodeWithTag("descriptionTag").performTextClearance()
+    composeTestRule.onNodeWithTag("descriptionTag").performTextInput("test")
+
+    assert(eventCopy.description == "test")
   }
 }

--- a/app/src/androidTest/java/com/android/streetworkapp/ui/parkoverview/AddEventTest.kt
+++ b/app/src/androidTest/java/com/android/streetworkapp/ui/parkoverview/AddEventTest.kt
@@ -1,11 +1,14 @@
 package com.android.streetworkapp.ui.parkoverview
 
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performGesture
 import androidx.compose.ui.test.swipeRight
 import com.android.streetworkapp.model.event.Event
 import com.android.streetworkapp.ui.park.ParticipantNumberSelection
+import com.android.streetworkapp.ui.park.TimeSelection
 import com.google.firebase.Timestamp
 import org.junit.Before
 import org.junit.Rule
@@ -39,5 +42,18 @@ class AddEventTest {
     // the slider
     composeTestRule.onNodeWithTag("sliderMaxParticipants").performGesture { this.swipeRight() }
     assert(eventCopy.maxParticipants == 10)
+  }
+
+  @OptIn(ExperimentalMaterial3Api::class)
+  @Test
+  fun timeSelectionUpdatesEvent() {
+    val eventCopy = event.copy()
+    assert(eventCopy.date == Timestamp(0, 0))
+    composeTestRule.setContent { TimeSelection(eventCopy) }
+    composeTestRule.onNodeWithTag("dateIcon").performClick()
+    composeTestRule.onNodeWithTag("validateDate").performClick()
+    composeTestRule.onNodeWithTag("timeIcon").performClick()
+    composeTestRule.onNodeWithTag("validateTime").performClick()
+    assert(eventCopy.date != Timestamp(0, 0))
   }
 }

--- a/app/src/androidTest/java/com/android/streetworkapp/ui/parkoverview/AddEventTest.kt
+++ b/app/src/androidTest/java/com/android/streetworkapp/ui/parkoverview/AddEventTest.kt
@@ -1,0 +1,43 @@
+package com.android.streetworkapp.ui.parkoverview
+
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performGesture
+import androidx.compose.ui.test.swipeRight
+import com.android.streetworkapp.model.event.Event
+import com.android.streetworkapp.ui.park.ParticipantNumberSelection
+import com.google.firebase.Timestamp
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+class AddEventTest {
+
+  private lateinit var event: Event
+
+  @get:Rule val composeTestRule = createComposeRule()
+
+  @Before
+  fun setUp() {
+    event =
+        Event(
+            eid = "1",
+            title = "Group workout",
+            description = "A fun group workout session to train new skills",
+            participants = 3,
+            maxParticipants = 5,
+            date = Timestamp(0, 0), // 01/01/1970 00:00
+            owner = "user123")
+  }
+
+  @Test
+  fun participantNumberSelectionUpdatesEvent() {
+    val eventCopy = event.copy()
+    assert(eventCopy.maxParticipants == 5)
+    composeTestRule.setContent { ParticipantNumberSelection(eventCopy) }
+    // Deprecated "performGesture" is used, because "performTouchInput" does not seem to work with
+    // the slider
+    composeTestRule.onNodeWithTag("sliderMaxParticipants").performGesture { this.swipeRight() }
+    assert(eventCopy.maxParticipants == 10)
+  }
+}

--- a/app/src/androidTest/java/com/android/streetworkapp/ui/parkoverview/AddEventTest.kt
+++ b/app/src/androidTest/java/com/android/streetworkapp/ui/parkoverview/AddEventTest.kt
@@ -1,6 +1,7 @@
 package com.android.streetworkapp.ui.parkoverview
 
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
@@ -9,6 +10,8 @@ import androidx.compose.ui.test.performTextClearance
 import androidx.compose.ui.test.performTextInput
 import androidx.compose.ui.test.swipeRight
 import com.android.streetworkapp.model.event.Event
+import com.android.streetworkapp.ui.navigation.NavigationActions
+import com.android.streetworkapp.ui.park.AddEventScreen
 import com.android.streetworkapp.ui.park.EventDescriptionSelection
 import com.android.streetworkapp.ui.park.EventTitleSelection
 import com.android.streetworkapp.ui.park.ParticipantNumberSelection
@@ -17,15 +20,19 @@ import com.google.firebase.Timestamp
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import org.mockito.Mockito.mock
 
 class AddEventTest {
 
   private lateinit var event: Event
+  private lateinit var navigationActions: NavigationActions
 
   @get:Rule val composeTestRule = createComposeRule()
 
   @Before
   fun setUp() {
+    navigationActions = mock(NavigationActions::class.java)
+
     event =
         Event(
             eid = "1",
@@ -79,5 +86,13 @@ class AddEventTest {
     composeTestRule.onNodeWithTag("descriptionTag").performTextInput("test")
 
     assert(eventCopy.description == "test")
+  }
+
+  @Test
+  fun addEventScreenIsDisplayed() {
+    composeTestRule.setContent { AddEventScreen(navigationActions) }
+    composeTestRule.onNodeWithTag("goBackButton").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("addEventScreen").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("addEventButton").assertIsDisplayed()
   }
 }

--- a/app/src/main/java/com/android/streetworkapp/model/event/Event.kt
+++ b/app/src/main/java/com/android/streetworkapp/model/event/Event.kt
@@ -29,3 +29,9 @@ data class Event(
  * @param events The list of events.
  */
 data class EventList(val events: List<Event>)
+
+/** Constant values for events. */
+object EventConstants {
+  const val MAX_NUMBER_PARTICIPANTS = 10
+  const val MIN_NUMBER_PARTICIPANTS = 2
+}

--- a/app/src/main/java/com/android/streetworkapp/ui/park/AddEvent.kt
+++ b/app/src/main/java/com/android/streetworkapp/ui/park/AddEvent.kt
@@ -1,21 +1,51 @@
 package com.android.streetworkapp.ui.park
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.AddCircle
+import androidx.compose.material.icons.filled.DateRange
+import androidx.compose.material3.Button
+import androidx.compose.material3.DatePicker
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Slider
 import androidx.compose.material3.SliderDefaults
 import androidx.compose.material3.Text
+import androidx.compose.material3.TimePicker
+import androidx.compose.material3.rememberDatePickerState
+import androidx.compose.material3.rememberTimePickerState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Popup
 import com.android.streetworkapp.model.event.Event
+import com.google.firebase.Timestamp
+import java.text.SimpleDateFormat
+import java.util.Calendar
+import java.util.Date
+import java.util.Locale
+import java.util.TimeZone
+import java.util.concurrent.TimeUnit
 
 /** Display a view that is used to add a new Event to a given park. */
 @Composable fun AddEventScreen() {}
@@ -51,4 +81,105 @@ fun ParticipantNumberSelection(event: Event) {
       }
 }
 
-@Composable fun TimeSelection() {}
+@ExperimentalMaterial3Api
+@Composable
+fun TimeSelection(event: Event) {
+  var showDatePicker by remember { mutableStateOf(false) }
+  var showTimePicker by remember { mutableStateOf(false) }
+  val datePickerState = rememberDatePickerState()
+
+  val currentTime = Calendar.getInstance()
+  val timePickerState =
+      rememberTimePickerState(
+          initialHour = currentTime.get(Calendar.HOUR_OF_DAY),
+          initialMinute = currentTime.get(Calendar.MINUTE),
+          is24Hour = false,
+      )
+
+  val currentTimeSelection =
+      datePickerState.selectedDateMillis?.plus(
+          (TimeUnit.HOURS.toMillis(timePickerState.hour.toLong()) +
+              TimeUnit.MINUTES.toMillis(timePickerState.minute.toLong())))
+
+  val selectedDate =
+      datePickerState.selectedDateMillis?.let { convertMillisToDate(it + currentTimeSelection!!) }
+          ?: ""
+
+  Box(modifier = Modifier.fillMaxWidth()) {
+    OutlinedTextField(
+        value = selectedDate,
+        onValueChange = {},
+        label = { Text("When do you want to train?") },
+        readOnly = true,
+        trailingIcon = {
+          Row {
+            IconButton(onClick = { showDatePicker = !showDatePicker }) {
+              Icon(imageVector = Icons.Default.DateRange, contentDescription = "Select date")
+            }
+            IconButton(onClick = { showTimePicker = !showTimePicker }) {
+              Icon(imageVector = Icons.Default.AddCircle, contentDescription = "Select date")
+            }
+          }
+        },
+        modifier = Modifier.fillMaxWidth().height(64.dp))
+
+    if (showDatePicker) {
+      Popup(onDismissRequest = { showDatePicker = false }, alignment = Alignment.TopStart) {
+        Box(
+            modifier =
+                Modifier.fillMaxWidth()
+                    .offset(y = 64.dp)
+                    .shadow(elevation = 4.dp)
+                    .background(MaterialTheme.colorScheme.surface)
+                    .padding(16.dp)) {
+              DatePicker(state = datePickerState, showModeToggle = false)
+            }
+
+        Button(
+            modifier = Modifier.offset(x = 280.dp, y = 140.dp),
+            onClick = {
+              showDatePicker = false
+
+              event.date =
+                  datePickerState.selectedDateMillis
+                      ?.let { TimeUnit.MILLISECONDS.toSeconds(it + currentTimeSelection!!) }
+                      ?.let { Timestamp(it, 0) }!!
+            }) {
+              Text("Validate")
+            }
+      }
+    }
+
+    if (showTimePicker) {
+      Popup(onDismissRequest = { showTimePicker = false }, alignment = Alignment.TopStart) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            modifier =
+                Modifier.fillMaxSize()
+                    .offset(y = 68.dp)
+                    .background(MaterialTheme.colorScheme.surface)
+                    .align(Alignment.Center)) {
+              TimePicker(state = timePickerState, modifier = Modifier.fillMaxWidth())
+
+              Button(
+                  onClick = {
+                    showTimePicker = false
+
+                    event.date =
+                        datePickerState.selectedDateMillis
+                            ?.let { TimeUnit.MILLISECONDS.toSeconds(it + currentTimeSelection!!) }
+                            ?.let { Timestamp(it, 0) }!!
+                  }) {
+                    Text("Validate")
+                  }
+            }
+      }
+    }
+  }
+}
+
+private fun convertMillisToDate(millis: Long): String {
+  val formatter = SimpleDateFormat("dd/MM/yyyy HH:mm", Locale.getDefault())
+  formatter.timeZone = TimeZone.getTimeZone("UTC")
+  return formatter.format(Date(millis))
+}

--- a/app/src/main/java/com/android/streetworkapp/ui/park/AddEvent.kt
+++ b/app/src/main/java/com/android/streetworkapp/ui/park/AddEvent.kt
@@ -10,20 +10,26 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.AddCircle
 import androidx.compose.material.icons.filled.DateRange
 import androidx.compose.material3.Button
 import androidx.compose.material3.DatePicker
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Slider
 import androidx.compose.material3.SliderDefaults
 import androidx.compose.material3.Text
 import androidx.compose.material3.TimePicker
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.rememberDatePickerState
 import androidx.compose.material3.rememberTimePickerState
 import androidx.compose.runtime.Composable
@@ -37,8 +43,10 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.Popup
 import com.android.streetworkapp.model.event.Event
+import com.android.streetworkapp.ui.navigation.NavigationActions
 import com.google.firebase.Timestamp
 import java.text.SimpleDateFormat
 import java.util.Calendar
@@ -47,9 +55,77 @@ import java.util.Locale
 import java.util.TimeZone
 import java.util.concurrent.TimeUnit
 
-/** Display a view that is used to add a new Event to a given park. */
-@Composable fun AddEventScreen() {}
+/**
+ * Display a view that is used to add a new Event to a given park.
+ *
+ * @param navigationActions used to navigate in the app
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun AddEventScreen(
+    navigationActions: NavigationActions
+) { // TODO: add future ParkViewModel and EventViewModel
 
+  // used until we have the corresponding viewModel TODO: update with new viewModel
+  val event = Event("unknown", "unknown", "unknown", 0, 2, Timestamp(0, 0), "unknown")
+
+  Scaffold(
+      modifier = Modifier.background(MaterialTheme.colorScheme.background),
+      topBar = {
+        TopAppBar(
+            title = {},
+            colors =
+                TopAppBarDefaults.topAppBarColors(
+                    containerColor = MaterialTheme.colorScheme.background),
+            navigationIcon = {
+              IconButton(
+                  onClick = { navigationActions.goBack() },
+                  modifier = Modifier.testTag("goBackButton")) {
+                    Icon(
+                        Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Arrow Back Icon")
+                  }
+            })
+      }) { innerPadding ->
+        Box(modifier = Modifier.padding(innerPadding).fillMaxSize().testTag("addEventScreen")) {
+          Column(
+              modifier = Modifier.fillMaxWidth(),
+              verticalArrangement = Arrangement.spacedBy(18.dp),
+              horizontalAlignment = Alignment.CenterHorizontally) {
+                Text(
+                    text = "Event Creation",
+                    fontSize = 24.sp,
+                )
+                EventTitleSelection(event)
+                EventDescriptionSelection(event)
+                TimeSelection(event)
+                Text(
+                    text = "How many participants do you want?",
+                    fontSize = 18.sp,
+                )
+                ParticipantNumberSelection(event)
+              }
+          FloatingActionButton(
+              onClick = {
+                // TODO: use one of the future viewModel to add the event to firebase
+                navigationActions.goBack()
+              },
+              modifier =
+                  Modifier.align(Alignment.BottomCenter)
+                      .padding(40.dp)
+                      .size(width = 150.dp, height = 40.dp)
+                      .testTag("addEventButton"),
+          ) {
+            Text("Add new event")
+          }
+        }
+      }
+}
+
+/**
+ * Used to change the title of the event
+ *
+ * @param event the event that will be updated
+ */
 @Composable
 fun EventTitleSelection(event: Event) {
   var title by remember { mutableStateOf("") }
@@ -61,9 +137,14 @@ fun EventTitleSelection(event: Event) {
         event.title = title
       },
       label = { Text("What kind of event do you want to create?") },
-      modifier = Modifier.testTag("titleTag").fillMaxWidth().height(64.dp))
+      modifier = Modifier.testTag("titleTag").fillMaxWidth(0.9f).height(64.dp))
 }
 
+/**
+ * Used to change the description of the event
+ *
+ * @param event the event that will be updated
+ */
 @Composable
 fun EventDescriptionSelection(event: Event) {
   var description by remember { mutableStateOf("") }
@@ -75,9 +156,14 @@ fun EventDescriptionSelection(event: Event) {
         event.description = description
       },
       label = { Text("Describe your event:") },
-      modifier = Modifier.testTag("descriptionTag").fillMaxWidth().height(64.dp))
+      modifier = Modifier.testTag("descriptionTag").fillMaxWidth(0.9f).height(128.dp))
 }
 
+/**
+ * Used to change the maximum number of participants of the event
+ *
+ * @param event the event that will be updated
+ */
 @Composable
 fun ParticipantNumberSelection(event: Event) {
   val minParticipants = 2 // We need at least 2 users for every event
@@ -107,6 +193,11 @@ fun ParticipantNumberSelection(event: Event) {
       }
 }
 
+/**
+ * Used to change the date and the hour of the event
+ *
+ * @param event the event that will be updated
+ */
 @ExperimentalMaterial3Api
 @Composable
 fun TimeSelection(event: Event) {
@@ -130,7 +221,7 @@ fun TimeSelection(event: Event) {
   val selectedDate =
       datePickerState.selectedDateMillis?.let { convertMillisToDate(currentTimeSelection!!) } ?: ""
 
-  Box(modifier = Modifier.fillMaxWidth()) {
+  Box(modifier = Modifier.fillMaxWidth(0.9f)) {
     OutlinedTextField(
         value = selectedDate,
         onValueChange = {},
@@ -157,7 +248,6 @@ fun TimeSelection(event: Event) {
         Box(
             modifier =
                 Modifier.fillMaxWidth()
-                    .offset(y = 64.dp)
                     .shadow(elevation = 4.dp)
                     .background(MaterialTheme.colorScheme.surface)
                     .padding(16.dp)) {
@@ -185,7 +275,7 @@ fun TimeSelection(event: Event) {
             horizontalAlignment = Alignment.CenterHorizontally,
             modifier =
                 Modifier.fillMaxSize()
-                    .offset(y = 68.dp)
+                    .offset(y = 10.dp)
                     .background(MaterialTheme.colorScheme.surface)
                     .align(Alignment.Center)) {
               TimePicker(state = timePickerState, modifier = Modifier.fillMaxWidth())

--- a/app/src/main/java/com/android/streetworkapp/ui/park/AddEvent.kt
+++ b/app/src/main/java/com/android/streetworkapp/ui/park/AddEvent.kt
@@ -167,7 +167,9 @@ fun EventDescriptionSelection(event: Event) {
  */
 @Composable
 fun ParticipantNumberSelection(event: Event) {
-  var sliderPosition by remember { mutableFloatStateOf(EventConstants.MIN_NUMBER_PARTICIPANTS.toFloat()) }
+  var sliderPosition by remember {
+    mutableFloatStateOf(EventConstants.MIN_NUMBER_PARTICIPANTS.toFloat())
+  }
 
   Column(
       verticalArrangement = Arrangement.Center,
@@ -187,7 +189,10 @@ fun ParticipantNumberSelection(event: Event) {
                     inactiveTrackColor = MaterialTheme.colorScheme.secondaryContainer,
                 ),
             steps = 7,
-            valueRange = EventConstants.MIN_NUMBER_PARTICIPANTS.toFloat()..EventConstants.MAX_NUMBER_PARTICIPANTS.toFloat())
+            valueRange =
+                EventConstants.MIN_NUMBER_PARTICIPANTS.toFloat()..EventConstants
+                        .MAX_NUMBER_PARTICIPANTS
+                        .toFloat())
         Text(text = sliderPosition.toInt().toString())
       }
 }

--- a/app/src/main/java/com/android/streetworkapp/ui/park/AddEvent.kt
+++ b/app/src/main/java/com/android/streetworkapp/ui/park/AddEvent.kt
@@ -61,7 +61,7 @@ fun EventTitleSelection(event: Event) {
         event.title = title
       },
       label = { Text("What kind of event do you want to create?") },
-      modifier = Modifier.fillMaxWidth().height(64.dp))
+      modifier = Modifier.testTag("titleTag").fillMaxWidth().height(64.dp))
 }
 
 @Composable
@@ -72,10 +72,10 @@ fun EventDescriptionSelection(event: Event) {
       value = description,
       onValueChange = {
         description = it
-        event.title = description
+        event.description = description
       },
       label = { Text("Describe your event:") },
-      modifier = Modifier.fillMaxWidth().height(64.dp))
+      modifier = Modifier.testTag("descriptionTag").fillMaxWidth().height(64.dp))
 }
 
 @Composable

--- a/app/src/main/java/com/android/streetworkapp/ui/park/AddEvent.kt
+++ b/app/src/main/java/com/android/streetworkapp/ui/park/AddEvent.kt
@@ -14,6 +14,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
 import com.android.streetworkapp.model.event.Event
 
 /** Display a view that is used to add a new Event to a given park. */
@@ -32,7 +33,7 @@ fun ParticipantNumberSelection(event: Event) {
       horizontalAlignment = Alignment.CenterHorizontally,
       modifier = Modifier.fillMaxWidth()) {
         Slider(
-            modifier = Modifier.fillMaxWidth(0.8f),
+            modifier = Modifier.fillMaxWidth(0.8f).testTag("sliderMaxParticipants"),
             value = sliderPosition,
             onValueChange = {
               sliderPosition = it

--- a/app/src/main/java/com/android/streetworkapp/ui/park/AddEvent.kt
+++ b/app/src/main/java/com/android/streetworkapp/ui/park/AddEvent.kt
@@ -1,0 +1,12 @@
+package com.android.streetworkapp.ui.park
+
+import androidx.compose.runtime.Composable
+
+/** Display a view that is used to add a new Event to a given park. */
+@Composable fun AddEventScreen() {}
+
+@Composable fun EventTypeSelection() {}
+
+@Composable fun ParticipantNumberSelection() {}
+
+@Composable fun TimeSelection() {}

--- a/app/src/main/java/com/android/streetworkapp/ui/park/AddEvent.kt
+++ b/app/src/main/java/com/android/streetworkapp/ui/park/AddEvent.kt
@@ -13,8 +13,8 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material.icons.filled.AddCircle
 import androidx.compose.material.icons.filled.DateRange
+import androidx.compose.material.icons.outlined.AccessTime
 import androidx.compose.material3.Button
 import androidx.compose.material3.DatePicker
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -241,7 +241,7 @@ fun TimeSelection(event: Event) {
             IconButton(
                 modifier = Modifier.testTag("timeIcon"),
                 onClick = { showTimePicker = !showTimePicker }) {
-                  Icon(imageVector = Icons.Default.AddCircle, contentDescription = "Select time")
+                  Icon(imageVector = Icons.Outlined.AccessTime, contentDescription = "Select time")
                 }
           }
         },

--- a/app/src/main/java/com/android/streetworkapp/ui/park/AddEvent.kt
+++ b/app/src/main/java/com/android/streetworkapp/ui/park/AddEvent.kt
@@ -1,12 +1,53 @@
 package com.android.streetworkapp.ui.park
 
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Slider
+import androidx.compose.material3.SliderDefaults
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import com.android.streetworkapp.model.event.Event
 
 /** Display a view that is used to add a new Event to a given park. */
 @Composable fun AddEventScreen() {}
 
 @Composable fun EventTypeSelection() {}
 
-@Composable fun ParticipantNumberSelection() {}
+@Composable
+fun ParticipantNumberSelection(event: Event) {
+  val minParticipants = 2 // We need at least 2 users for every event
+  val maxParticipants = 10 // An event can not have more then 10 participants
+  var sliderPosition by remember { mutableFloatStateOf(minParticipants.toFloat()) }
+
+  Column(
+      verticalArrangement = Arrangement.Center,
+      horizontalAlignment = Alignment.CenterHorizontally,
+      modifier = Modifier.fillMaxWidth()) {
+        Slider(
+            modifier = Modifier.fillMaxWidth(0.8f),
+            value = sliderPosition,
+            onValueChange = {
+              sliderPosition = it
+              event.maxParticipants = sliderPosition.toInt()
+            },
+            colors =
+                SliderDefaults.colors(
+                    thumbColor = MaterialTheme.colorScheme.secondary,
+                    activeTrackColor = MaterialTheme.colorScheme.secondary,
+                    inactiveTrackColor = MaterialTheme.colorScheme.secondaryContainer,
+                ),
+            steps = 7,
+            valueRange = minParticipants.toFloat()..maxParticipants.toFloat())
+        Text(text = sliderPosition.toInt().toString())
+      }
+}
 
 @Composable fun TimeSelection() {}

--- a/app/src/main/java/com/android/streetworkapp/ui/park/AddEvent.kt
+++ b/app/src/main/java/com/android/streetworkapp/ui/park/AddEvent.kt
@@ -50,7 +50,33 @@ import java.util.concurrent.TimeUnit
 /** Display a view that is used to add a new Event to a given park. */
 @Composable fun AddEventScreen() {}
 
-@Composable fun EventTypeSelection() {}
+@Composable
+fun EventTitleSelection(event: Event) {
+  var title by remember { mutableStateOf("") }
+
+  OutlinedTextField(
+      value = title,
+      onValueChange = {
+        title = it
+        event.title = title
+      },
+      label = { Text("What kind of event do you want to create?") },
+      modifier = Modifier.fillMaxWidth().height(64.dp))
+}
+
+@Composable
+fun EventDescriptionSelection(event: Event) {
+  var description by remember { mutableStateOf("") }
+
+  OutlinedTextField(
+      value = description,
+      onValueChange = {
+        description = it
+        event.title = description
+      },
+      label = { Text("Describe your event:") },
+      modifier = Modifier.fillMaxWidth().height(64.dp))
+}
 
 @Composable
 fun ParticipantNumberSelection(event: Event) {

--- a/app/src/main/java/com/android/streetworkapp/ui/park/AddEvent.kt
+++ b/app/src/main/java/com/android/streetworkapp/ui/park/AddEvent.kt
@@ -46,6 +46,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.Popup
 import com.android.streetworkapp.model.event.Event
+import com.android.streetworkapp.model.event.EventConstants
 import com.android.streetworkapp.ui.navigation.NavigationActions
 import com.google.firebase.Timestamp
 import java.text.SimpleDateFormat
@@ -166,9 +167,7 @@ fun EventDescriptionSelection(event: Event) {
  */
 @Composable
 fun ParticipantNumberSelection(event: Event) {
-  val minParticipants = 2 // We need at least 2 users for every event
-  val maxParticipants = 10 // An event can not have more then 10 participants
-  var sliderPosition by remember { mutableFloatStateOf(minParticipants.toFloat()) }
+  var sliderPosition by remember { mutableFloatStateOf(EventConstants.MIN_NUMBER_PARTICIPANTS.toFloat()) }
 
   Column(
       verticalArrangement = Arrangement.Center,
@@ -188,7 +187,7 @@ fun ParticipantNumberSelection(event: Event) {
                     inactiveTrackColor = MaterialTheme.colorScheme.secondaryContainer,
                 ),
             steps = 7,
-            valueRange = minParticipants.toFloat()..maxParticipants.toFloat())
+            valueRange = EventConstants.MIN_NUMBER_PARTICIPANTS.toFloat()..EventConstants.MAX_NUMBER_PARTICIPANTS.toFloat())
         Text(text = sliderPosition.toInt().toString())
       }
 }

--- a/app/src/main/java/com/android/streetworkapp/ui/park/AddEvent.kt
+++ b/app/src/main/java/com/android/streetworkapp/ui/park/AddEvent.kt
@@ -86,9 +86,9 @@ fun ParticipantNumberSelection(event: Event) {
 fun TimeSelection(event: Event) {
   var showDatePicker by remember { mutableStateOf(false) }
   var showTimePicker by remember { mutableStateOf(false) }
-  val datePickerState = rememberDatePickerState()
 
   val currentTime = Calendar.getInstance()
+  val datePickerState = rememberDatePickerState(currentTime.timeInMillis)
   val timePickerState =
       rememberTimePickerState(
           initialHour = currentTime.get(Calendar.HOUR_OF_DAY),
@@ -102,8 +102,7 @@ fun TimeSelection(event: Event) {
               TimeUnit.MINUTES.toMillis(timePickerState.minute.toLong())))
 
   val selectedDate =
-      datePickerState.selectedDateMillis?.let { convertMillisToDate(it + currentTimeSelection!!) }
-          ?: ""
+      datePickerState.selectedDateMillis?.let { convertMillisToDate(currentTimeSelection!!) } ?: ""
 
   Box(modifier = Modifier.fillMaxWidth()) {
     OutlinedTextField(
@@ -113,12 +112,16 @@ fun TimeSelection(event: Event) {
         readOnly = true,
         trailingIcon = {
           Row {
-            IconButton(onClick = { showDatePicker = !showDatePicker }) {
-              Icon(imageVector = Icons.Default.DateRange, contentDescription = "Select date")
-            }
-            IconButton(onClick = { showTimePicker = !showTimePicker }) {
-              Icon(imageVector = Icons.Default.AddCircle, contentDescription = "Select date")
-            }
+            IconButton(
+                modifier = Modifier.testTag("dateIcon"),
+                onClick = { showDatePicker = !showDatePicker }) {
+                  Icon(imageVector = Icons.Default.DateRange, contentDescription = "Select date")
+                }
+            IconButton(
+                modifier = Modifier.testTag("timeIcon"),
+                onClick = { showTimePicker = !showTimePicker }) {
+                  Icon(imageVector = Icons.Default.AddCircle, contentDescription = "Select time")
+                }
           }
         },
         modifier = Modifier.fillMaxWidth().height(64.dp))
@@ -136,13 +139,13 @@ fun TimeSelection(event: Event) {
             }
 
         Button(
-            modifier = Modifier.offset(x = 280.dp, y = 140.dp),
+            modifier = Modifier.offset(x = 280.dp, y = 140.dp).testTag("validateDate"),
             onClick = {
               showDatePicker = false
 
               event.date =
                   datePickerState.selectedDateMillis
-                      ?.let { TimeUnit.MILLISECONDS.toSeconds(it + currentTimeSelection!!) }
+                      ?.let { TimeUnit.MILLISECONDS.toSeconds(currentTimeSelection!!) }
                       ?.let { Timestamp(it, 0) }!!
             }) {
               Text("Validate")
@@ -162,12 +165,13 @@ fun TimeSelection(event: Event) {
               TimePicker(state = timePickerState, modifier = Modifier.fillMaxWidth())
 
               Button(
+                  modifier = Modifier.testTag("validateTime"),
                   onClick = {
                     showTimePicker = false
 
                     event.date =
                         datePickerState.selectedDateMillis
-                            ?.let { TimeUnit.MILLISECONDS.toSeconds(it + currentTimeSelection!!) }
+                            ?.let { TimeUnit.MILLISECONDS.toSeconds(currentTimeSelection!!) }
                             ?.let { Timestamp(it, 0) }!!
                   }) {
                     Text("Validate")

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -47,6 +47,7 @@ firebaseUiAuth = "8.0.0"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
+androidx-material-icons-extended = { module = "androidx.compose.material:material-icons-extended" }
 json = { module = "org.json:json", version.ref = "json" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }


### PR DESCRIPTION
**An UI to create new events**

The objective of this pull request is to add a new screen that will be used to create and add a new event to a given park. I tried as much as possible to make sure that the interface is easily usable on a smartphone. This is the reason why a slider is used for the selection of the maximum number of participants of an event. The selection of the date selection is improved to also allow the user to pick a specific hour of the day, since it is important to have a clear hour for the events.

The UI is not totally functional yet, as it will need a viewModel for the parks and one for the events in order to be able to use Firebase. Those viewModels should be available soon.

**Features**
- two text field to specify the name and the description of the event
- A "time selection" composable, that can be used to first select the date, and then the hour of the event
- A slider to select the maximum number of participants

**Objective of the PR**
In addition of any improvement you might suggest, I would really appreciate a feedback about the user experience. In particular, do you think that this UI is easily usable on a smartphone? (If anyone could try on a real device, I think it could be useful)

**Screenshots**
<img width="242" alt="image" src="https://github.com/user-attachments/assets/1987a47f-bfa4-40ca-8253-c10ae81ba110">

<img width="242" alt="image" src="https://github.com/user-attachments/assets/2c72711d-269a-449f-bad9-08ff744b0a2a">

<img width="241" alt="image" src="https://github.com/user-attachments/assets/d07e0f15-e9a7-4dab-9694-03dd528329db">



