### PR TITLE
Feat/link composables with navigation

### DIFF
--- a/app/src/androidTest/java/com/android/streetworkapp/end2end/End2EndParks.kt
+++ b/app/src/androidTest/java/com/android/streetworkapp/end2end/End2EndParks.kt
@@ -1,0 +1,171 @@
+package com.android.streetworkapp.end2end
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.click
+import androidx.compose.ui.test.getUnclippedBoundsInRoot
+import androidx.compose.ui.test.isDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performTouchInput
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.height
+import androidx.compose.ui.unit.size
+import androidx.test.espresso.IdlingRegistry
+import androidx.test.espresso.idling.CountingIdlingResource
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.android.streetworkapp.StreetWorkApp
+import com.android.streetworkapp.model.parklocation.OverpassParkLocationRepository
+import com.android.streetworkapp.model.parklocation.ParkLocation
+import com.android.streetworkapp.model.parklocation.ParkLocationViewModel
+import com.android.streetworkapp.ui.navigation.Route
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.After
+import org.junit.Before
+import org.junit.Ignore
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.ArgumentMatchers.any
+
+@RunWith(AndroidJUnit4::class)
+class End2EndParks {
+
+  @get:Rule val composeTestRule = createComposeRule()
+
+  private lateinit var parkLocationRepository: OverpassParkLocationRepository
+  private lateinit var parkLocationViewModel: ParkLocationViewModel
+
+  private val idlingResource =
+      CountingIdlingResource(
+          "MapLoading") // this is to make sure the map and markers are loaded for the test
+
+  @Before
+  fun setUp() {
+    val mockParkList =
+        listOf(
+            ParkLocation(
+                lat = 46.518659400000004,
+                lon = 6.566561505148001,
+                id = "1"), // TODO: change so that it always equals default cam pos
+            ParkLocation(lat = 34.052235, lon = -118.243683, id = "2"),
+            ParkLocation(lat = 51.507351, lon = -0.127758, id = "3"),
+            ParkLocation(lat = 35.676192, lon = 139.650311, id = "4"),
+            ParkLocation(lat = -33.868820, lon = 151.209290, id = "5"))
+
+    parkLocationRepository =
+        mockk<OverpassParkLocationRepository>() // TODO: check why interface doens't work
+    every {
+      parkLocationRepository.search(
+          any<Double>(),
+          any<Double>(),
+          any<(List<ParkLocation>) -> Unit>(),
+          any<(Exception) -> Unit>())
+    } answers
+        {
+          val onSuccess = this.args[2] as (List<ParkLocation>) -> Unit
+          onSuccess(mockParkList) // Invoke onSuccess with the custom list
+        }
+
+    parkLocationViewModel = ParkLocationViewModel(parkLocationRepository)
+    IdlingRegistry.getInstance().register(idlingResource)
+  }
+
+  @After
+  fun cleanUp() {
+    // Unregister the Idling Resource
+    IdlingRegistry.getInstance().unregister(idlingResource)
+  }
+
+  @Ignore("google maps API can be slow sometimes, wouldn't want the CI to fail because of this")
+  @Test
+  fun E2ECanClickParkAncAccessSpecificParkOverview() {
+    idlingResource.increment()
+    composeTestRule.setContent {
+      StreetWorkApp(
+          parkLocationViewModel,
+          { navigateTo(Route.MAP) },
+          { idlingResource.decrement() }) // setup so as we're already on the MAP route
+    }
+
+    // Testing we can click on the marker that's already placed at the center of the screen and
+    // we're being redirected to its park overview page
+    composeTestRule.waitUntil { idlingResource.isIdleNow }
+
+    val bounds = composeTestRule.onNodeWithTag("mapScreen").getUnclippedBoundsInRoot()
+    val xClickOffset = bounds.left + bounds.size.width / 2
+    val yClickOffset = bounds.top + bounds.size.height / 2
+
+    val bottomBarBounds =
+        composeTestRule.onNodeWithTag("bottomNavigationMenu").getUnclippedBoundsInRoot()
+    val yOffsetCorr =
+        bottomBarBounds
+            .height // for some reason the height of the map matches the one of the screen not the
+    // actual size it does :)))))))))), this is an ugly fix to correct the position
+    // of the click
+
+    composeTestRule.onNodeWithTag("mapScreen").performTouchInput {
+      click(Offset(xClickOffset.toPx(), yClickOffset.toPx() - yOffsetCorr.toPx()))
+    }
+
+    composeTestRule.waitUntil(
+        10000) { // this value is arbitrary, we just don't want the test to completely halt. Might
+          // need to tune it for the CI
+          composeTestRule.onNodeWithTag("ParkOverview").isDisplayed()
+        }
+
+    composeTestRule.onNodeWithTag("ParkOverview").assertIsDisplayed()
+
+    // we're going to check if the park matches the one we should have clicked on
+    // TODO: tbd, can't be implemented yet as necessary features aren't on github yet
+  }
+}
+
+// Below is what I used to be able to visualize where the offsets where, this can be useful for
+// debugging later so I'll leave it in (even though it's not used anymore atm)
+@Composable
+fun PositionedComposable(offset: Offset) {
+  Box(
+      modifier = Modifier.fillMaxSize() // Ensure the container fills the available space
+      ) {
+        // Create a circle at the specified offset
+        CircleIndicator(modifier = Modifier.offset(offset.x.toDp(), offset.y.toDp()))
+
+        // Optional: Add any other content here
+        Text(
+            text = "Circle at ${offset.x}, ${offset.y}",
+            modifier = Modifier.align(Alignment.TopStart),
+            color = Color.Black)
+      }
+}
+
+@Composable
+fun CircleIndicator(modifier: Modifier = Modifier) {
+  Box(
+      modifier =
+          modifier
+              .size(20.dp) // Size of the visual indicator
+              .background(Color.Red) // Circle shape (red background)
+      )
+}
+
+// Extension function to convert Float to Dp
+@Composable
+fun Float.toDp(): Dp {
+  return (this / LocalDensity.current.density).dp
+}

--- a/app/src/androidTest/java/com/android/streetworkapp/ui/parkoverview/ParkOverviewTest.kt
+++ b/app/src/androidTest/java/com/android/streetworkapp/ui/parkoverview/ParkOverviewTest.kt
@@ -1,5 +1,6 @@
 package com.android.streetworkapp.ui.parkoverview
 
+import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertTextContains
 import androidx.compose.ui.test.assertTextEquals
 import androidx.compose.ui.test.isDisplayed
@@ -10,15 +11,20 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.android.streetworkapp.model.event.Event
 import com.android.streetworkapp.model.event.EventList
 import com.android.streetworkapp.model.park.Park
+import com.android.streetworkapp.ui.navigation.NavigationActions
 import com.android.streetworkapp.ui.park.OccupancyBar
+import com.android.streetworkapp.ui.park.ParkOverview
 import com.android.streetworkapp.ui.park.ParkOverviewScreen
 import com.android.streetworkapp.ui.park.RatingComponent
 import com.google.firebase.Timestamp
+import io.mockk.verify
 import org.junit.Assert.assertThrows
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.Mockito.mock
+import org.mockito.kotlin.verify
 
 @RunWith(AndroidJUnit4::class)
 class ParkOverviewTest {
@@ -27,10 +33,15 @@ class ParkOverviewTest {
   private lateinit var invalidRatingPark: Park
   private lateinit var invalidOccupancyPark: Park
 
+  // Mocks
+  private lateinit var navigationActions: NavigationActions
+
   @get:Rule val composeTestRule = createComposeRule()
 
   @Before
   fun setUp() {
+    navigationActions = mock(NavigationActions::class.java)
+
     val eventList =
         EventList(
             events =
@@ -67,7 +78,7 @@ class ParkOverviewTest {
   }
 
   @Test
-  fun hasRequiredComponents() {
+  fun parkOverviewScreenhasRequiredComponents() {
     composeTestRule.setContent { ParkOverviewScreen(park) }
     composeTestRule.onNodeWithTag("parkOverviewScreen").isDisplayed()
     composeTestRule.onNodeWithTag("imageTitle").isDisplayed()
@@ -88,7 +99,7 @@ class ParkOverviewTest {
   }
 
   @Test
-  fun displayCorrectParkDetails() {
+  fun parkOverviewScreenDisplaysCorrectParkDetails() {
     composeTestRule.setContent { ParkOverviewScreen(park) }
     composeTestRule.onNodeWithTag("title").assertTextEquals("EPFL Esplanade")
     composeTestRule.onNodeWithTag("nbrReview").assertTextEquals("(102)")
@@ -96,7 +107,7 @@ class ParkOverviewTest {
   }
 
   @Test
-  fun displayCorrectEvent() {
+  fun parkOverviewScreenDisplaysCorrectEvent() {
     composeTestRule.setContent { ParkOverviewScreen(park) }
     composeTestRule.onNodeWithTag("createEventButton").assertTextEquals("Create an event")
     composeTestRule.onNodeWithTag("eventItem").assertTextContains("Group workout")
@@ -112,28 +123,28 @@ class ParkOverviewTest {
   }
 
   @Test
-  fun displayTextWhenNoEvent() {
+  fun parkOverviewScreenDisplaysTextWhenNoEvent() {
     composeTestRule.setContent { ParkOverviewScreen(noEventPark) }
     composeTestRule.onNodeWithTag("noEventText").isDisplayed()
     composeTestRule.onNodeWithTag("noEventText").assertTextEquals("No event is planned yet")
   }
 
   @Test
-  fun buttonAreClickable() {
+  fun parkOverviewScreenButtonsAreClickable() {
     composeTestRule.setContent { ParkOverviewScreen(park) }
     composeTestRule.onNodeWithTag("eventButton").performClick()
     composeTestRule.onNodeWithTag("createEventButton").performClick()
   }
 
   @Test
-  fun invalidRatingTriggersException() {
+  fun parkOverviewScreenInvalidRatingTriggersException() {
     assertThrows(IllegalArgumentException::class.java) {
       composeTestRule.setContent { ParkOverviewScreen(invalidRatingPark) }
     }
   }
 
   @Test
-  fun invalidOccupancyTriggersException() {
+  fun parkOverviewScreenInvalidOccupancyTriggersException() {
     assertThrows(IllegalArgumentException::class.java) {
       composeTestRule.setContent { ParkOverviewScreen(invalidOccupancyPark) }
     }
@@ -165,5 +176,21 @@ class ParkOverviewTest {
     composeTestRule.setContent { OccupancyBar(occupancy = 1.0f) }
     composeTestRule.onNodeWithTag("occupancyBar").isDisplayed()
     composeTestRule.onNodeWithTag("occupancyText").assertTextEquals("100% Occupancy")
+  }
+
+  @Test
+  fun topBarAndParkOverviewScreenAreDisplayedInParkOverview() {
+    composeTestRule.setContent { ParkOverview(navigationActions, park) }
+
+    composeTestRule.onNodeWithTag("ParkOverviewTopBar").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("parkOverviewScreen").assertIsDisplayed()
+  }
+
+  @Test
+  fun topBarArrowBackCallsNavigationActionsGoBack() {
+    composeTestRule.setContent { ParkOverview(navigationActions, park) }
+
+    composeTestRule.onNodeWithTag("goBackButtonOverviewScreen").performClick()
+    verify(navigationActions).goBack()
   }
 }

--- a/app/src/androidTest/java/com/android/streetworkapp/ui/parkoverview/ParkOverviewTest.kt
+++ b/app/src/androidTest/java/com/android/streetworkapp/ui/parkoverview/ParkOverviewTest.kt
@@ -78,7 +78,7 @@ class ParkOverviewTest {
   }
 
   @Test
-  fun parkOverviewScreenhasRequiredComponents() {
+  fun parkOverviewScreenHasRequiredComponents() {
     composeTestRule.setContent { ParkOverviewScreen(park) }
     composeTestRule.onNodeWithTag("parkOverviewScreen").isDisplayed()
     composeTestRule.onNodeWithTag("imageTitle").isDisplayed()

--- a/app/src/main/java/com/android/streetworkapp/MainActivity.kt
+++ b/app/src/main/java/com/android/streetworkapp/MainActivity.kt
@@ -4,7 +4,14 @@ import android.os.Bundle
 import android.util.Log
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
@@ -85,7 +92,14 @@ fun StreetWorkApp(
             startDestination = Screen.AUTH,
             route = Route.AUTH,
         ) {
-          composable(Screen.AUTH) {}
+          composable(Screen.AUTH) {
+            Column(
+                modifier = Modifier.fillMaxSize(),
+                verticalArrangement = Arrangement.Center,
+                horizontalAlignment = Alignment.CenterHorizontally) {
+                  Button(onClick = { navigationActions.navigateTo(Route.MAP) }) { Text("Start") }
+                }
+          }
         }
 
         navigation(

--- a/app/src/main/java/com/android/streetworkapp/ui/map/MapUi.kt
+++ b/app/src/main/java/com/android/streetworkapp/ui/map/MapUi.kt
@@ -12,6 +12,7 @@ import com.android.streetworkapp.model.parklocation.ParkLocationViewModel
 import com.android.streetworkapp.ui.navigation.BottomNavigationMenu
 import com.android.streetworkapp.ui.navigation.LIST_TOP_LEVEL_DESTINATION
 import com.android.streetworkapp.ui.navigation.NavigationActions
+import com.android.streetworkapp.ui.navigation.Screen
 import com.google.android.gms.maps.model.CameraPosition
 import com.google.android.gms.maps.model.LatLng
 import com.google.maps.android.compose.GoogleMap
@@ -26,7 +27,11 @@ import com.google.maps.android.compose.rememberCameraPositionState
  * @param navigationActions The navigation actions to navigate to other screens.
  */
 @Composable
-fun MapScreen(parkLocationViewModel: ParkLocationViewModel, navigationActions: NavigationActions) {
+fun MapScreen(
+    parkLocationViewModel: ParkLocationViewModel,
+    navigationActions: NavigationActions,
+    callbackOnMapLoaded: () -> Unit = {}
+) {
 
   // hardcoded initial location values are used instead of the user's current location for now
   val initialLatLng = LatLng(46.518659400000004, 6.566561505148001)
@@ -52,14 +57,18 @@ fun MapScreen(parkLocationViewModel: ParkLocationViewModel, navigationActions: N
 
         // Display the Google Map
         GoogleMap(
+            onMapLoaded = callbackOnMapLoaded,
             modifier = Modifier.fillMaxSize().padding(innerPadding).testTag("googleMap"),
             cameraPositionState = cameraPositionState) {
               parks.forEach { park ->
                 Marker(
                     contentDescription = "Marker",
                     state = MarkerState(position = LatLng(park.lat, park.lon)),
-                    /** onClick = { navigationActions.navigateTo(Screen.UNK) true } */
-                )
+                    onClick = {
+                      // TODO: selectPark
+                      navigationActions.navigateTo(Screen.PARK_OVERVIEW)
+                      true
+                    })
               }
             }
       }

--- a/app/src/main/java/com/android/streetworkapp/ui/navigation/NavigationActions.kt
+++ b/app/src/main/java/com/android/streetworkapp/ui/navigation/NavigationActions.kt
@@ -17,6 +17,7 @@ object Screen {
   const val AUTH = "Auth Screen"
   const val MAP = "Map Screen"
   const val PROFILE = "Profile Screen"
+  const val PARK_OVERVIEW = "Park Overview Screen"
   const val UNK = "TBD Screen" // TODO: not yet defined
 }
 

--- a/app/src/main/java/com/android/streetworkapp/ui/park/ParkOverview.kt
+++ b/app/src/main/java/com/android/streetworkapp/ui/park/ParkOverview.kt
@@ -56,45 +56,62 @@ import com.android.streetworkapp.utils.toFormattedString
 /**
  * Display the overview of a park, including park details and a list of events.
  *
+ * @param navigationActions navigation class
  * @param park The park data to display.
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun ParkOverviewScreen(navigationActions: NavigationActions, park: Park) {
-    Scaffold(
-        topBar = {
-            TopAppBar(
-                title = { },
-                colors = TopAppBarDefaults.topAppBarColors(containerColor = MaterialTheme.colorScheme.surface),
-                navigationIcon = {
-                    IconButton(
-                        onClick = { navigationActions.goBack() },
-                        modifier = Modifier.testTag("goBackButton")) {
-                        Icon(
-                            Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Arrow Back Icon")
-                    }
-                })
-        }) { innerPadding ->
-        Box(modifier = Modifier.padding(innerPadding).fillMaxSize().testTag("parkOverviewScreen")) {
-            Column {
-                ImageTitle(image = park.image, title = park.name)
-                ParkDetails(park = park)
-                EventItemList(eventList = park.events)
-            }
-            FloatingActionButton(
-                onClick = {
-                    Log.d("ParkOverviewScreen", "Create event button clicked") // TODO: Handle button click
-                },
-                modifier =
-                Modifier.align(Alignment.BottomCenter)
-                    .padding(40.dp)
-                    .size(width = 150.dp, height = 40.dp)
-                    .testTag("createEventButton"),
-            ) {
-                Text("Create an event")
-            }
-        }
+fun ParkOverview(navigationActions: NavigationActions, park: Park) {
+  Scaffold(
+      modifier = Modifier.testTag("ParkOverview"),
+      topBar = {
+        TopAppBar(
+            modifier = Modifier.testTag("ParkOverviewTopBar"),
+            title = {},
+            colors =
+                TopAppBarDefaults.topAppBarColors(
+                    containerColor = MaterialTheme.colorScheme.surface),
+            navigationIcon = {
+              IconButton(
+                  onClick = { navigationActions.goBack() },
+                  modifier = Modifier.testTag("goBackButtonOverviewScreen")) {
+                    Icon(
+                        Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Arrow Back Icon")
+                  }
+            })
+      }) { innerPadding ->
+        ParkOverviewScreen(
+            park, innerPadding) // we declare this so that it doesn't impact the tests in
+        // PackOverviewScreen (exceptions wouldn't be caught as it's async and
+        // tests would fail)
+      }
+}
+/**
+ * Display the overview of a park, including park details and a list of events.
+ *
+ * @param park The park data to display.
+ */
+@Composable
+fun ParkOverviewScreen(park: Park, innerPadding: PaddingValues = PaddingValues(0.dp)) {
+  Box(modifier = Modifier.padding(innerPadding).fillMaxSize().testTag("parkOverviewScreen")) {
+    Column {
+      ImageTitle(image = park.image, title = park.name)
+      ParkDetails(park = park)
+      EventItemList(eventList = park.events)
     }
+    FloatingActionButton(
+        onClick = {
+          Log.d("ParkOverviewScreen", "Create event button clicked") // TODO: Handle button click
+        },
+        modifier =
+            Modifier.align(Alignment.BottomCenter)
+                .padding(40.dp)
+                .size(width = 150.dp, height = 40.dp)
+                .testTag("createEventButton"),
+    ) {
+      Text("Create an event")
+    }
+  }
 }
 
 /**

--- a/app/src/main/java/com/android/streetworkapp/ui/park/ParkOverview.kt
+++ b/app/src/main/java/com/android/streetworkapp/ui/park/ParkOverview.kt
@@ -17,16 +17,23 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.AccountCircle
 import androidx.compose.material.icons.filled.Star
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.ListItem
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -43,6 +50,7 @@ import com.android.sample.R
 import com.android.streetworkapp.model.event.Event
 import com.android.streetworkapp.model.event.EventList
 import com.android.streetworkapp.model.park.Park
+import com.android.streetworkapp.ui.navigation.NavigationActions
 import com.android.streetworkapp.utils.toFormattedString
 
 /**
@@ -50,27 +58,43 @@ import com.android.streetworkapp.utils.toFormattedString
  *
  * @param park The park data to display.
  */
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun ParkOverviewScreen(park: Park) {
-  Box(modifier = Modifier.fillMaxSize().testTag("parkOverviewScreen")) {
-    Column {
-      ImageTitle(image = park.image, title = park.name)
-      ParkDetails(park = park)
-      EventItemList(eventList = park.events)
+fun ParkOverviewScreen(navigationActions: NavigationActions, park: Park) {
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { },
+                colors = TopAppBarDefaults.topAppBarColors(containerColor = MaterialTheme.colorScheme.surface),
+                navigationIcon = {
+                    IconButton(
+                        onClick = { navigationActions.goBack() },
+                        modifier = Modifier.testTag("goBackButton")) {
+                        Icon(
+                            Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Arrow Back Icon")
+                    }
+                })
+        }) { innerPadding ->
+        Box(modifier = Modifier.padding(innerPadding).fillMaxSize().testTag("parkOverviewScreen")) {
+            Column {
+                ImageTitle(image = park.image, title = park.name)
+                ParkDetails(park = park)
+                EventItemList(eventList = park.events)
+            }
+            FloatingActionButton(
+                onClick = {
+                    Log.d("ParkOverviewScreen", "Create event button clicked") // TODO: Handle button click
+                },
+                modifier =
+                Modifier.align(Alignment.BottomCenter)
+                    .padding(40.dp)
+                    .size(width = 150.dp, height = 40.dp)
+                    .testTag("createEventButton"),
+            ) {
+                Text("Create an event")
+            }
+        }
     }
-    FloatingActionButton(
-        onClick = {
-          Log.d("ParkOverviewScreen", "Create event button clicked") // TODO: Handle button click
-        },
-        modifier =
-            Modifier.align(Alignment.BottomCenter)
-                .padding(40.dp)
-                .size(width = 150.dp, height = 40.dp)
-                .testTag("createEventButton"),
-    ) {
-      Text("Create an event")
-    }
-  }
 }
 
 /**


### PR DESCRIPTION
- **ParkOverview TopBar:**
  - Created the TopBar in the ParkOverview Composable to easily navigate back to the map
  - Implemented tests for this new element in the already existing `ParkOverviewTest.kt` file
  - Added `ParkOverviewScreen` prefix to the old tests in `ParkOverviewTest.kt` to remove ambiguities
 
- **Navigation:**
  - Defined a new screen `Park Overview Screen` for our new ParkOverview Composable

- **MainActivity:**
  - Added the StreetWorkAppMain composable, this allows us to create our repos, viewmodels etc... before calling StreetWorkApp. This allows for easy injecting of mocks in our tests
  - Updated the hierarchy to include the ParkOverview Composable inside our `Map` route 

- **End2End Tests:**
  - Added a new parameter `callbackOnMapLoaded` that gets called once the GoogleMap Composable has finished loading, its default value is {}
  - Added a file `End2EndParks.kt` containing a new `E2ECanClickParkAncAccessSpecificParkOverview` test. **Note**: This test has a `@Ignore` tag to it as sometimes Google Map can take some time to load and make the test fail (very rare but can happen). This test is designed to run locally as one wouldn't want the CI to fail because of an external API.