### PR TITLE
Make the AddEvent Screen functional

### DIFF
--- a/app/src/androidTest/java/com/android/streetworkapp/end2end/End2EndParks.kt
+++ b/app/src/androidTest/java/com/android/streetworkapp/end2end/End2EndParks.kt
@@ -29,6 +29,8 @@ import androidx.test.espresso.IdlingRegistry
 import androidx.test.espresso.idling.CountingIdlingResource
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.android.streetworkapp.StreetWorkApp
+import com.android.streetworkapp.model.event.EventViewModel
+import com.android.streetworkapp.model.park.ParkViewModel
 import com.android.streetworkapp.model.parklocation.OverpassParkLocationRepository
 import com.android.streetworkapp.model.parklocation.ParkLocation
 import com.android.streetworkapp.model.parklocation.ParkLocationViewModel
@@ -102,7 +104,10 @@ class End2EndParks {
           parkLocationViewModel,
           { navigateTo(Route.MAP) },
           { idlingResource.decrement() },
-          UserViewModel(mockk())) // setup so as we're already on the MAP route
+          UserViewModel(mockk()),
+          ParkViewModel(mockk()),
+          EventViewModel(mockk()))
+      // setup so as we're already on the MAP route
     }
 
     // Testing we can click on the marker that's already placed at the center of the screen and

--- a/app/src/androidTest/java/com/android/streetworkapp/ui/parkoverview/AddEventTest.kt
+++ b/app/src/androidTest/java/com/android/streetworkapp/ui/parkoverview/AddEventTest.kt
@@ -10,6 +10,12 @@ import androidx.compose.ui.test.performTextClearance
 import androidx.compose.ui.test.performTextInput
 import androidx.compose.ui.test.swipeRight
 import com.android.streetworkapp.model.event.Event
+import com.android.streetworkapp.model.event.EventRepository
+import com.android.streetworkapp.model.event.EventViewModel
+import com.android.streetworkapp.model.park.ParkRepository
+import com.android.streetworkapp.model.park.ParkViewModel
+import com.android.streetworkapp.model.user.UserRepository
+import com.android.streetworkapp.model.user.UserViewModel
 import com.android.streetworkapp.ui.navigation.NavigationActions
 import com.android.streetworkapp.ui.park.AddEventScreen
 import com.android.streetworkapp.ui.park.EventDescriptionSelection
@@ -21,17 +27,34 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
 
 class AddEventTest {
 
   private lateinit var event: Event
   private lateinit var navigationActions: NavigationActions
+  private lateinit var userRepository: UserRepository
+  private lateinit var userViewModel: UserViewModel
+
+  private lateinit var parkRepository: ParkRepository
+  private lateinit var parkViewModel: ParkViewModel
+
+  private lateinit var eventRepository: EventRepository
+  private lateinit var eventViewModel: EventViewModel
 
   @get:Rule val composeTestRule = createComposeRule()
 
   @Before
   fun setUp() {
     navigationActions = mock(NavigationActions::class.java)
+    userRepository = mock(UserRepository::class.java)
+    userViewModel = UserViewModel(userRepository)
+
+    parkRepository = mock(ParkRepository::class.java)
+    parkViewModel = ParkViewModel(parkRepository)
+
+    eventRepository = mock(EventRepository::class.java)
+    eventViewModel = EventViewModel(eventRepository)
 
     event =
         Event(
@@ -90,7 +113,10 @@ class AddEventTest {
 
   @Test
   fun addEventScreenIsDisplayed() {
-    composeTestRule.setContent { AddEventScreen(navigationActions) }
+    `when`(eventViewModel.getNewEid()).thenReturn("test")
+    composeTestRule.setContent {
+      AddEventScreen(navigationActions, parkViewModel, eventViewModel, userViewModel)
+    }
     composeTestRule.onNodeWithTag("goBackButton").assertIsDisplayed()
     composeTestRule.onNodeWithTag("addEventScreen").assertIsDisplayed()
     composeTestRule.onNodeWithTag("addEventButton").assertIsDisplayed()

--- a/app/src/main/java/com/android/streetworkapp/MainActivity.kt
+++ b/app/src/main/java/com/android/streetworkapp/MainActivity.kt
@@ -9,7 +9,11 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navigation
+import com.android.streetworkapp.model.event.EventRepositoryFirestore
+import com.android.streetworkapp.model.event.EventViewModel
 import com.android.streetworkapp.model.park.Park
+import com.android.streetworkapp.model.park.ParkRepositoryFirestore
+import com.android.streetworkapp.model.park.ParkViewModel
 import com.android.streetworkapp.model.parklocation.OverpassParkLocationRepository
 import com.android.streetworkapp.model.parklocation.ParkLocation
 import com.android.streetworkapp.model.parklocation.ParkLocationViewModel
@@ -20,6 +24,7 @@ import com.android.streetworkapp.ui.map.MapScreen
 import com.android.streetworkapp.ui.navigation.NavigationActions
 import com.android.streetworkapp.ui.navigation.Route
 import com.android.streetworkapp.ui.navigation.Screen
+import com.android.streetworkapp.ui.park.AddEventScreen
 import com.android.streetworkapp.ui.park.ParkOverview
 import com.android.streetworkapp.ui.profile.AddFriendScreen
 import com.android.streetworkapp.ui.profile.ProfileScreen
@@ -49,7 +54,16 @@ fun StreetWorkAppMain(testInvokation: NavigationActions.() -> Unit = {}) {
   val userRepository = UserRepositoryFirestore(firestoreDB)
   val userViewModel = UserViewModel(userRepository)
 
-  StreetWorkApp(parkLocationViewModel, testInvokation, {}, userViewModel)
+  // Instantiate park repository :
+  val parkRepository = ParkRepositoryFirestore(firestoreDB)
+  val parkViewModel = ParkViewModel(parkRepository)
+
+  // Instantiate event repository :
+  val eventRepository = EventRepositoryFirestore(firestoreDB)
+  val eventViewModel = EventViewModel(eventRepository)
+
+  StreetWorkApp(
+      parkLocationViewModel, testInvokation, {}, userViewModel, parkViewModel, eventViewModel)
 }
 
 @Composable
@@ -58,6 +72,8 @@ fun StreetWorkApp(
     navTestInvokation: NavigationActions.() -> Unit = {},
     mapCallbackOnMapLoaded: () -> Unit = {},
     userViewModel: UserViewModel,
+    parkViewModel: ParkViewModel,
+    eventViewModel: EventViewModel
 ) {
   val navController = rememberNavController()
   val navigationActions = NavigationActions(navController)
@@ -93,6 +109,9 @@ fun StreetWorkApp(
             MapScreen(parkLocationViewModel, navigationActions, mapCallbackOnMapLoaded)
           }
           composable(Screen.PARK_OVERVIEW) { ParkOverview(navigationActions, testPark) }
+          composable(Screen.ADD_EVENT) {
+            AddEventScreen(navigationActions, parkViewModel, eventViewModel, userViewModel)
+          }
         }
 
         navigation(

--- a/app/src/main/java/com/android/streetworkapp/model/event/Event.kt
+++ b/app/src/main/java/com/android/streetworkapp/model/event/Event.kt
@@ -12,6 +12,8 @@ import com.google.firebase.Timestamp
  * @param maxParticipants The maximum number of participants.
  * @param date The event date.
  * @param owner The event owner.
+ * @param listParticipants The list of id of users.
+ * @param parkId The id of the park for this event.
  */
 data class Event(
     val eid: String,
@@ -21,6 +23,9 @@ data class Event(
     var maxParticipants: Int,
     var date: Timestamp,
     var owner: String,
+    var listParticipants: List<String> = emptyList(),
+    var parkId: String = "Unknown Park"
+    // Default parameters can be removed once the viewModels are updated
 )
 
 /**

--- a/app/src/main/java/com/android/streetworkapp/model/event/EventRepository.kt
+++ b/app/src/main/java/com/android/streetworkapp/model/event/EventRepository.kt
@@ -1,0 +1,9 @@
+package com.android.streetworkapp.model.event
+
+/** A repository interface for event data. */
+interface EventRepository {
+
+  fun getNewEid(): String
+
+  suspend fun createEvent(event: Event)
+}

--- a/app/src/main/java/com/android/streetworkapp/model/event/EventRepository.kt
+++ b/app/src/main/java/com/android/streetworkapp/model/event/EventRepository.kt
@@ -5,5 +5,5 @@ interface EventRepository {
 
   fun getNewEid(): String
 
-  suspend fun createEvent(event: Event)
+  suspend fun addEvent(event: Event)
 }

--- a/app/src/main/java/com/android/streetworkapp/model/event/EventRepositoryFirestore.kt
+++ b/app/src/main/java/com/android/streetworkapp/model/event/EventRepositoryFirestore.kt
@@ -1,0 +1,36 @@
+package com.android.streetworkapp.model.event
+
+import android.util.Log
+import com.google.firebase.firestore.FirebaseFirestore
+import kotlinx.coroutines.tasks.await
+
+/** A repository interface using Firestore for park data. */
+class EventRepositoryFirestore(private val db: FirebaseFirestore) : EventRepository {
+
+  companion object {
+    private const val COLLECTION_PATH = "events"
+  }
+
+  /**
+   * Get a new event ID.
+   *
+   * @return A new event ID.
+   */
+  override fun getNewEid(): String {
+    return db.collection(COLLECTION_PATH).document().id
+  }
+
+  /**
+   * Add a new event in the database.
+   *
+   * @param event The event to add.
+   */
+  override suspend fun addEvent(event: Event) {
+    require(event.eid.isNotEmpty())
+    try {
+      db.collection(COLLECTION_PATH).document(event.eid).set(event).await()
+    } catch (e: Exception) {
+      Log.e("FirestoreError", "Error creating event: ${e.message}")
+    }
+  }
+}

--- a/app/src/main/java/com/android/streetworkapp/model/event/EventViewModel.kt
+++ b/app/src/main/java/com/android/streetworkapp/model/event/EventViewModel.kt
@@ -1,0 +1,24 @@
+package com.android.streetworkapp.model.event
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.launch
+
+open class EventViewModel(private val repository: EventRepository) : ViewModel() {
+
+  /**
+   * Get a new event ID.
+   *
+   * @return A new event ID.
+   */
+  fun getNewEid(): String {
+    return repository.getNewEid()
+  }
+
+  /**
+   * Add a new event to the database.
+   *
+   * @param event The event to add.
+   */
+  fun addEvent(event: Event) = viewModelScope.launch { repository.addEvent(event) }
+}

--- a/app/src/main/java/com/android/streetworkapp/ui/navigation/NavigationActions.kt
+++ b/app/src/main/java/com/android/streetworkapp/ui/navigation/NavigationActions.kt
@@ -19,6 +19,7 @@ object Screen {
   const val PROFILE = "Profile Screen"
   const val ADD_FRIEND = "AddFriend Screen"
   const val PARK_OVERVIEW = "Park Overview Screen"
+  const val ADD_EVENT = "Add Event Screen"
   const val UNK = "TBD Screen" // TODO: not yet defined
 }
 

--- a/app/src/main/java/com/android/streetworkapp/ui/park/AddEvent.kt
+++ b/app/src/main/java/com/android/streetworkapp/ui/park/AddEvent.kt
@@ -1,5 +1,6 @@
 package com.android.streetworkapp.ui.park
 
+import android.widget.Toast
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -41,6 +42,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -73,13 +75,15 @@ fun AddEventScreen(
     userViewModel: UserViewModel
 ) {
 
+  val context = LocalContext.current
+
   val eid = eventViewModel.getNewEid()
   val event =
       Event(
           eid,
-          "unknown",
-          "unknown",
-          0,
+          "",
+          "",
+          1, // set to one by default, because the owner is also a participant
           EventConstants.MIN_NUMBER_PARTICIPANTS,
           Timestamp(0, 0),
           "unknown")
@@ -89,7 +93,7 @@ fun AddEventScreen(
     event.owner = owner
   }
 
-  val parkId = "Unkown park" // TODO: do the same with ParkViewModel once updated
+  val parkId = "Unknown park" // TODO: do the same with ParkViewModel once updated
   if (!parkId.isNullOrEmpty()) {
     event.parkId = parkId
   }
@@ -132,8 +136,14 @@ fun AddEventScreen(
           FloatingActionButton(
               onClick = {
                 // TODO: check that it works on the database
-                eventViewModel.addEvent(event)
-                navigationActions.goBack()
+
+                if (event.title.isEmpty()) {
+                  Toast.makeText(context, "Please fill the title of the event", Toast.LENGTH_SHORT)
+                      .show()
+                } else {
+                  eventViewModel.addEvent(event)
+                  navigationActions.goBack()
+                }
               },
               modifier =
                   Modifier.align(Alignment.BottomCenter)

--- a/app/src/main/java/com/android/streetworkapp/ui/park/AddEvent.kt
+++ b/app/src/main/java/com/android/streetworkapp/ui/park/AddEvent.kt
@@ -47,6 +47,9 @@ import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.Popup
 import com.android.streetworkapp.model.event.Event
 import com.android.streetworkapp.model.event.EventConstants
+import com.android.streetworkapp.model.event.EventViewModel
+import com.android.streetworkapp.model.park.ParkViewModel
+import com.android.streetworkapp.model.user.UserViewModel
 import com.android.streetworkapp.ui.navigation.NavigationActions
 import com.google.firebase.Timestamp
 import java.text.SimpleDateFormat
@@ -64,11 +67,32 @@ import java.util.concurrent.TimeUnit
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun AddEventScreen(
-    navigationActions: NavigationActions
-) { // TODO: add future ParkViewModel and EventViewModel
+    navigationActions: NavigationActions,
+    parkViewModel: ParkViewModel,
+    eventViewModel: EventViewModel,
+    userViewModel: UserViewModel
+) {
 
-  // used until we have the corresponding viewModel TODO: update with new viewModel
-  val event = Event("unknown", "unknown", "unknown", 0, 2, Timestamp(0, 0), "unknown")
+  val eid = eventViewModel.getNewEid()
+  val event =
+      Event(
+          eid,
+          "unknown",
+          "unknown",
+          0,
+          EventConstants.MIN_NUMBER_PARTICIPANTS,
+          Timestamp(0, 0),
+          "unknown")
+
+  val owner = userViewModel.currentUser.value?.uid
+  if (!owner.isNullOrEmpty()) {
+    event.owner = owner
+  }
+
+  val parkId = "Unkown park" // TODO: do the same with ParkViewModel once updated
+  if (!parkId.isNullOrEmpty()) {
+    event.parkId = parkId
+  }
 
   Scaffold(
       modifier = Modifier.background(MaterialTheme.colorScheme.background),
@@ -107,7 +131,8 @@ fun AddEventScreen(
               }
           FloatingActionButton(
               onClick = {
-                // TODO: use one of the future viewModel to add the event to firebase
+                // TODO: check that it works on the database
+                eventViewModel.addEvent(event)
                 navigationActions.goBack()
               },
               modifier =

--- a/app/src/main/java/com/android/streetworkapp/ui/park/ParkOverview.kt
+++ b/app/src/main/java/com/android/streetworkapp/ui/park/ParkOverview.kt
@@ -46,11 +46,13 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.navigation.compose.rememberNavController
 import com.android.sample.R
 import com.android.streetworkapp.model.event.Event
 import com.android.streetworkapp.model.event.EventList
 import com.android.streetworkapp.model.park.Park
 import com.android.streetworkapp.ui.navigation.NavigationActions
+import com.android.streetworkapp.ui.navigation.Screen
 import com.android.streetworkapp.utils.toFormattedString
 
 /**
@@ -81,7 +83,9 @@ fun ParkOverview(navigationActions: NavigationActions, park: Park) {
             })
       }) { innerPadding ->
         ParkOverviewScreen(
-            park, innerPadding) // we declare this so that it doesn't impact the tests in
+            park,
+            innerPadding,
+            navigationActions) // we declare this so that it doesn't impact the tests in
         // PackOverviewScreen (exceptions wouldn't be caught as it's async and
         // tests would fail)
       }
@@ -92,7 +96,11 @@ fun ParkOverview(navigationActions: NavigationActions, park: Park) {
  * @param park The park data to display.
  */
 @Composable
-fun ParkOverviewScreen(park: Park, innerPadding: PaddingValues = PaddingValues(0.dp)) {
+fun ParkOverviewScreen(
+    park: Park,
+    innerPadding: PaddingValues = PaddingValues(0.dp),
+    navigationActions: NavigationActions = NavigationActions(rememberNavController())
+) {
   Box(modifier = Modifier.padding(innerPadding).fillMaxSize().testTag("parkOverviewScreen")) {
     Column {
       ImageTitle(image = null, title = park.name) // TODO: Fetch image from Firestore storage
@@ -101,6 +109,8 @@ fun ParkOverviewScreen(park: Park, innerPadding: PaddingValues = PaddingValues(0
     }
     FloatingActionButton(
         onClick = {
+          navigationActions.navigateTo(Screen.ADD_EVENT)
+
           Log.d("ParkOverviewScreen", "Create event button clicked") // TODO: Handle button click
         },
         modifier =

--- a/app/src/test/java/com/android/streetworkapp/model/event/EventRepositoryFirestoreTest.kt
+++ b/app/src/test/java/com/android/streetworkapp/model/event/EventRepositoryFirestoreTest.kt
@@ -1,0 +1,70 @@
+package com.android.streetworkapp.model.event
+
+import com.android.streetworkapp.model.park.Park
+import com.android.streetworkapp.model.park.ParkRepositoryFirestore
+import com.android.streetworkapp.model.parklocation.ParkLocation
+import com.google.android.gms.tasks.Tasks
+import com.google.firebase.Timestamp
+import com.google.firebase.firestore.CollectionReference
+import com.google.firebase.firestore.DocumentReference
+import com.google.firebase.firestore.DocumentSnapshot
+import com.google.firebase.firestore.FirebaseFirestore
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
+import org.mockito.kotlin.whenever
+
+class EventRepositoryFirestoreTest {
+
+    private lateinit var db: FirebaseFirestore
+    private lateinit var eventRepository: EventRepositoryFirestore
+    private lateinit var collection: CollectionReference
+    private lateinit var documentRef: DocumentReference
+    private lateinit var document: DocumentSnapshot
+
+    @Before
+    fun setUp() {
+        db = mock(FirebaseFirestore::class.java)
+        eventRepository = EventRepositoryFirestore(db)
+        collection = mock()
+        documentRef = mock()
+        document = mock()
+
+
+        whenever(db.collection("events")).thenReturn(collection)
+    }
+
+    @Test
+    fun getNewEidReturnsUniqueId() {
+        `when`(collection.document()).thenReturn(documentRef)
+        `when`(documentRef.id).thenReturn("uniqueEventId")
+
+        val eid = eventRepository.getNewEid()
+        assertEquals("uniqueEventId", eid)
+    }
+
+    @Test
+    fun addEventAddsEventSuccessfully() = runTest {
+        val event =
+        Event(
+            eid = "1",
+            title = "Group workout",
+            description = "A fun group workout session to train new skills",
+            participants = 3,
+            maxParticipants = 5,
+            date = Timestamp(0, 0), // 01/01/1970 00:00
+            owner = "user123")
+
+        `when`(collection.document(event.eid)).thenReturn(documentRef)
+        `when`(documentRef.set(event.eid)).thenReturn(Tasks.forResult(null))
+
+        eventRepository.addEvent(event)
+        verify(documentRef).set(event)
+    }
+
+
+}

--- a/app/src/test/java/com/android/streetworkapp/model/event/EventRepositoryFirestoreTest.kt
+++ b/app/src/test/java/com/android/streetworkapp/model/event/EventRepositoryFirestoreTest.kt
@@ -1,8 +1,5 @@
 package com.android.streetworkapp.model.event
 
-import com.android.streetworkapp.model.park.Park
-import com.android.streetworkapp.model.park.ParkRepositoryFirestore
-import com.android.streetworkapp.model.parklocation.ParkLocation
 import com.google.android.gms.tasks.Tasks
 import com.google.firebase.Timestamp
 import com.google.firebase.firestore.CollectionReference
@@ -20,36 +17,35 @@ import org.mockito.kotlin.whenever
 
 class EventRepositoryFirestoreTest {
 
-    private lateinit var db: FirebaseFirestore
-    private lateinit var eventRepository: EventRepositoryFirestore
-    private lateinit var collection: CollectionReference
-    private lateinit var documentRef: DocumentReference
-    private lateinit var document: DocumentSnapshot
+  private lateinit var db: FirebaseFirestore
+  private lateinit var eventRepository: EventRepositoryFirestore
+  private lateinit var collection: CollectionReference
+  private lateinit var documentRef: DocumentReference
+  private lateinit var document: DocumentSnapshot
 
-    @Before
-    fun setUp() {
-        db = mock(FirebaseFirestore::class.java)
-        eventRepository = EventRepositoryFirestore(db)
-        collection = mock()
-        documentRef = mock()
-        document = mock()
+  @Before
+  fun setUp() {
+    db = mock(FirebaseFirestore::class.java)
+    eventRepository = EventRepositoryFirestore(db)
+    collection = mock()
+    documentRef = mock()
+    document = mock()
 
+    whenever(db.collection("events")).thenReturn(collection)
+  }
 
-        whenever(db.collection("events")).thenReturn(collection)
-    }
+  @Test
+  fun getNewEidReturnsUniqueId() {
+    `when`(collection.document()).thenReturn(documentRef)
+    `when`(documentRef.id).thenReturn("uniqueEventId")
 
-    @Test
-    fun getNewEidReturnsUniqueId() {
-        `when`(collection.document()).thenReturn(documentRef)
-        `when`(documentRef.id).thenReturn("uniqueEventId")
+    val eid = eventRepository.getNewEid()
+    assertEquals("uniqueEventId", eid)
+  }
 
-        val eid = eventRepository.getNewEid()
-        assertEquals("uniqueEventId", eid)
-    }
-
-    @Test
-    fun addEventAddsEventSuccessfully() = runTest {
-        val event =
+  @Test
+  fun addEventAddsEventSuccessfully() = runTest {
+    val event =
         Event(
             eid = "1",
             title = "Group workout",
@@ -59,12 +55,10 @@ class EventRepositoryFirestoreTest {
             date = Timestamp(0, 0), // 01/01/1970 00:00
             owner = "user123")
 
-        `when`(collection.document(event.eid)).thenReturn(documentRef)
-        `when`(documentRef.set(event.eid)).thenReturn(Tasks.forResult(null))
+    `when`(collection.document(event.eid)).thenReturn(documentRef)
+    `when`(documentRef.set(event.eid)).thenReturn(Tasks.forResult(null))
 
-        eventRepository.addEvent(event)
-        verify(documentRef).set(event)
-    }
-
-
+    eventRepository.addEvent(event)
+    verify(documentRef).set(event)
+  }
 }

--- a/app/src/test/java/com/android/streetworkapp/model/event/EventViewModelTest.kt
+++ b/app/src/test/java/com/android/streetworkapp/model/event/EventViewModelTest.kt
@@ -1,0 +1,43 @@
+package com.android.streetworkapp.model.event
+
+import com.google.firebase.Timestamp
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.verify
+
+class EventViewModelTest {
+
+  private lateinit var repository: EventRepository
+  private lateinit var eventViewModel: EventViewModel
+  private val testDispatcher = StandardTestDispatcher()
+
+  @OptIn(ExperimentalCoroutinesApi::class)
+  @Before
+  fun setUp() {
+    Dispatchers.setMain(testDispatcher)
+    repository = mock()
+    eventViewModel = EventViewModel(repository)
+  }
+
+  @Test
+  fun addEventCallsRepository() = runTest {
+    val event =
+        Event(
+            eid = "1",
+            title = "Group workout",
+            description = "A fun group workout session to train new skills",
+            participants = 3,
+            maxParticipants = 5,
+            date = Timestamp(0, 0), // 01/01/1970 00:00
+            owner = "user123")
+    eventViewModel.addEvent(event)
+    testDispatcher.scheduler.advanceUntilIdle()
+    verify(repository).addEvent(event)
+  }
+}


### PR DESCRIPTION
**Make the AddEvent Screen functional**
As suggested during the last meeting, we decided to split the creation of the Event MVVM in two parts. This is the first part, whose objective is to create a way for the user to create new events that are added to the database.

**Features**
-  A first version of the EventViewModel, which is used to add new events to the database.
- An update of the previously defined AddEventScreen, with all the necessary view model as parameters to make it functional.
- An update of the main and the navigation, to be able to access the AddEventScreen.

**Limitations**
- The events are not yet linked to the currently selected park. It will be done once the ParkViewModel is updated and used in MapUI.

**How to test**
You can test this feature by running the app, and then:
Login -> On the map, select any park -> click on "create a new event" -> Fill the AddEventScreen

You can then check that the event you just created is in the database.
