### PR TITLE
feat/mvvm-get-events

### DIFF
--- a/app/src/androidTest/java/com/android/streetworkapp/ui/parkoverview/AddEventTest.kt
+++ b/app/src/androidTest/java/com/android/streetworkapp/ui/parkoverview/AddEventTest.kt
@@ -16,12 +16,12 @@ import com.android.streetworkapp.model.park.ParkRepository
 import com.android.streetworkapp.model.park.ParkViewModel
 import com.android.streetworkapp.model.user.UserRepository
 import com.android.streetworkapp.model.user.UserViewModel
+import com.android.streetworkapp.ui.event.AddEventScreen
+import com.android.streetworkapp.ui.event.EventDescriptionSelection
+import com.android.streetworkapp.ui.event.EventTitleSelection
+import com.android.streetworkapp.ui.event.ParticipantNumberSelection
+import com.android.streetworkapp.ui.event.TimeSelection
 import com.android.streetworkapp.ui.navigation.NavigationActions
-import com.android.streetworkapp.ui.park.AddEventScreen
-import com.android.streetworkapp.ui.park.EventDescriptionSelection
-import com.android.streetworkapp.ui.park.EventTitleSelection
-import com.android.streetworkapp.ui.park.ParticipantNumberSelection
-import com.android.streetworkapp.ui.park.TimeSelection
 import com.google.firebase.Timestamp
 import org.junit.Before
 import org.junit.Rule

--- a/app/src/androidTest/java/com/android/streetworkapp/ui/parkoverview/EventOverviewTest.kt
+++ b/app/src/androidTest/java/com/android/streetworkapp/ui/parkoverview/EventOverviewTest.kt
@@ -11,8 +11,8 @@ import com.android.streetworkapp.model.event.Event
 import com.android.streetworkapp.model.event.EventList
 import com.android.streetworkapp.model.park.Park
 import com.android.streetworkapp.model.parklocation.ParkLocation
+import com.android.streetworkapp.ui.event.EventOverviewScreen
 import com.android.streetworkapp.ui.navigation.NavigationActions
-import com.android.streetworkapp.ui.park.EventOverviewScreen
 import com.android.streetworkapp.utils.toFormattedString
 import com.google.firebase.Timestamp
 import org.junit.Before

--- a/app/src/main/java/com/android/streetworkapp/MainActivity.kt
+++ b/app/src/main/java/com/android/streetworkapp/MainActivity.kt
@@ -20,11 +20,11 @@ import com.android.streetworkapp.model.parklocation.ParkLocationViewModel
 import com.android.streetworkapp.model.user.UserRepositoryFirestore
 import com.android.streetworkapp.model.user.UserViewModel
 import com.android.streetworkapp.ui.authentication.SignInScreen
+import com.android.streetworkapp.ui.event.AddEventScreen
 import com.android.streetworkapp.ui.map.MapScreen
 import com.android.streetworkapp.ui.navigation.NavigationActions
 import com.android.streetworkapp.ui.navigation.Route
 import com.android.streetworkapp.ui.navigation.Screen
-import com.android.streetworkapp.ui.park.AddEventScreen
 import com.android.streetworkapp.ui.park.ParkOverview
 import com.android.streetworkapp.ui.profile.AddFriendScreen
 import com.android.streetworkapp.ui.profile.ProfileScreen
@@ -108,7 +108,9 @@ fun StreetWorkApp(
           composable(Screen.MAP) {
             MapScreen(parkLocationViewModel, navigationActions, mapCallbackOnMapLoaded)
           }
-          composable(Screen.PARK_OVERVIEW) { ParkOverview(navigationActions, testPark) }
+          composable(Screen.PARK_OVERVIEW) {
+            ParkOverview(navigationActions, testPark, eventViewModel)
+          }
           composable(Screen.ADD_EVENT) {
             AddEventScreen(navigationActions, parkViewModel, eventViewModel, userViewModel)
           }

--- a/app/src/main/java/com/android/streetworkapp/model/event/EventRepository.kt
+++ b/app/src/main/java/com/android/streetworkapp/model/event/EventRepository.kt
@@ -5,5 +5,7 @@ interface EventRepository {
 
   fun getNewEid(): String
 
+  fun getEvents(onSuccess: (List<Event>) -> Unit, onFailure: (Exception) -> Unit)
+
   suspend fun addEvent(event: Event)
 }

--- a/app/src/main/java/com/android/streetworkapp/model/event/EventViewModel.kt
+++ b/app/src/main/java/com/android/streetworkapp/model/event/EventViewModel.kt
@@ -1,10 +1,18 @@
 package com.android.streetworkapp.model.event
 
+import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 
 open class EventViewModel(private val repository: EventRepository) : ViewModel() {
+
+  private val _uiState: MutableStateFlow<EventOverviewUiState> =
+      MutableStateFlow(EventOverviewUiState.Empty)
+
+  val uiState: StateFlow<EventOverviewUiState> = _uiState
 
   /**
    * Get a new event ID.
@@ -15,10 +23,29 @@ open class EventViewModel(private val repository: EventRepository) : ViewModel()
     return repository.getNewEid()
   }
 
+  /** Fetch all events from the database. */
+  fun getEvents() {
+    repository.getEvents(
+        onSuccess = {
+          if (it.isEmpty()) {
+            _uiState.value = EventOverviewUiState.Empty
+          } else {
+            _uiState.value = EventOverviewUiState.NotEmpty(it)
+          }
+        },
+        onFailure = { Log.e("FirestoreError", "Error getting events: ${it.message}") })
+  }
+
   /**
    * Add a new event to the database.
    *
    * @param event The event to add.
    */
   fun addEvent(event: Event) = viewModelScope.launch { repository.addEvent(event) }
+}
+
+sealed class EventOverviewUiState {
+  data class NotEmpty(val eventList: List<Event>) : EventOverviewUiState()
+
+  data object Empty : EventOverviewUiState()
 }

--- a/app/src/main/java/com/android/streetworkapp/ui/event/AddEvent.kt
+++ b/app/src/main/java/com/android/streetworkapp/ui/event/AddEvent.kt
@@ -1,4 +1,4 @@
-package com.android.streetworkapp.ui.park
+package com.android.streetworkapp.ui.event
 
 import android.widget.Toast
 import androidx.compose.foundation.background

--- a/app/src/main/java/com/android/streetworkapp/ui/event/EventOverview.kt
+++ b/app/src/main/java/com/android/streetworkapp/ui/event/EventOverview.kt
@@ -1,4 +1,4 @@
-package com.android.streetworkapp.ui.park
+package com.android.streetworkapp.ui.event
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
@@ -60,7 +60,7 @@ import com.google.maps.android.compose.rememberCameraPositionState
 import kotlinx.coroutines.flow.MutableStateFlow
 
 // Mutable dashboard state
-private val uiState: MutableStateFlow<OverviewUiState> = MutableStateFlow(OverviewUiState.Details)
+private val uiState: MutableStateFlow<DashboardState> = MutableStateFlow(DashboardState.Details)
 
 /**
  * This screen displays an overview of a selcted event, including description location, location and
@@ -244,11 +244,11 @@ fun EventDashboard(event: Event) {
                     .heightIn(max = 220.dp) // Set the maximum height
                     .verticalScroll(rememberScrollState())) {
               when (uiState.collectAsState().value) {
-                OverviewUiState.Details ->
+                DashboardState.Details ->
                     Text(
                         event.description,
                         modifier = Modifier.padding(padding).testTag("eventDescription"))
-                OverviewUiState.Participants ->
+                DashboardState.Participants ->
                     Text(
                         "show participants",
                         modifier = Modifier.padding(padding).testTag("participantsList"))
@@ -271,20 +271,20 @@ fun DashBoardBar() {
     NavigationBarItem(
         modifier = Modifier.testTag("detailsTab"),
         icon = { Text("Details") },
-        selected = state == OverviewUiState.Details,
-        onClick = { uiState.value = OverviewUiState.Details })
+        selected = state == DashboardState.Details,
+        onClick = { uiState.value = DashboardState.Details })
 
     NavigationBarItem(
         modifier = Modifier.testTag("participantsTab"),
         icon = { Text("Participants") },
-        selected = state == OverviewUiState.Participants,
-        onClick = { uiState.value = OverviewUiState.Participants })
+        selected = state == DashboardState.Participants,
+        onClick = { uiState.value = DashboardState.Participants })
   }
 }
 
 /** Represents the different states of the event dashboard */
-sealed class OverviewUiState {
-  data object Details : OverviewUiState()
+sealed class DashboardState {
+  data object Details : DashboardState()
 
-  data object Participants : OverviewUiState()
+  data object Participants : DashboardState()
 }

--- a/app/src/main/java/com/android/streetworkapp/ui/park/ParkOverview.kt
+++ b/app/src/main/java/com/android/streetworkapp/ui/park/ParkOverview.kt
@@ -35,6 +35,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
@@ -49,7 +50,8 @@ import androidx.compose.ui.unit.sp
 import androidx.navigation.compose.rememberNavController
 import com.android.sample.R
 import com.android.streetworkapp.model.event.Event
-import com.android.streetworkapp.model.event.EventList
+import com.android.streetworkapp.model.event.EventOverviewUiState
+import com.android.streetworkapp.model.event.EventViewModel
 import com.android.streetworkapp.model.park.Park
 import com.android.streetworkapp.ui.navigation.NavigationActions
 import com.android.streetworkapp.ui.navigation.Screen
@@ -63,7 +65,9 @@ import com.android.streetworkapp.utils.toFormattedString
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun ParkOverview(navigationActions: NavigationActions, park: Park) {
+fun ParkOverview(navigationActions: NavigationActions, park: Park, eventViewModel: EventViewModel) {
+  eventViewModel.getEvents()
+
   Scaffold(
       modifier = Modifier.testTag("ParkOverview"),
       topBar = {
@@ -85,11 +89,13 @@ fun ParkOverview(navigationActions: NavigationActions, park: Park) {
         ParkOverviewScreen(
             park,
             innerPadding,
-            navigationActions) // we declare this so that it doesn't impact the tests in
+            navigationActions,
+            eventViewModel) // we declare this so that it doesn't impact the tests in
         // PackOverviewScreen (exceptions wouldn't be caught as it's async and
         // tests would fail)
       }
 }
+
 /**
  * Display the overview of a park, including park details and a list of events.
  *
@@ -99,13 +105,14 @@ fun ParkOverview(navigationActions: NavigationActions, park: Park) {
 fun ParkOverviewScreen(
     park: Park,
     innerPadding: PaddingValues = PaddingValues(0.dp),
-    navigationActions: NavigationActions = NavigationActions(rememberNavController())
+    navigationActions: NavigationActions = NavigationActions(rememberNavController()),
+    eventViewModel: EventViewModel
 ) {
   Box(modifier = Modifier.padding(innerPadding).fillMaxSize().testTag("parkOverviewScreen")) {
     Column {
       ImageTitle(image = null, title = park.name) // TODO: Fetch image from Firestore storage
       ParkDetails(park = park)
-      EventItemList(eventList = EventList(emptyList())) // TODO: Fetch events from Firestore
+      EventItemList(eventViewModel) // TODO: Fetch events from Firestore
     }
     FloatingActionButton(
         onClick = {
@@ -232,24 +239,30 @@ fun OccupancyBar(occupancy: Float) {
  * @param eventList The list of events to display.
  */
 @Composable
-fun EventItemList(eventList: EventList) {
+fun EventItemList(eventViewModel: EventViewModel) {
+  val uiState = eventViewModel.uiState.collectAsState().value
+
   Column(modifier = Modifier.testTag("eventItemList")) {
     Text(
         text = "Events",
         fontSize = 24.sp,
         fontWeight = FontWeight.Bold,
         modifier = Modifier.padding(start = 16.dp, top = 6.dp, bottom = 2.dp))
-    if (eventList.events.isEmpty()) {
-      Box(modifier = Modifier.fillMaxSize()) {
-        Text(
-            text = "No event is planned yet",
-            fontSize = 16.sp,
-            fontWeight = FontWeight.Light,
-            modifier =
-                Modifier.align(Alignment.Center).padding(bottom = 40.dp).testTag("noEventText"))
+
+    when (uiState) {
+      is EventOverviewUiState.NotEmpty -> {
+        LazyColumn { items(uiState.eventList) { event -> EventItem(event = event) } }
       }
-    } else {
-      LazyColumn { items(eventList.events) { event -> EventItem(event = event) } }
+      is EventOverviewUiState.Empty -> {
+        Box(modifier = Modifier.fillMaxSize()) {
+          Text(
+              text = "No event is planned yet",
+              fontSize = 16.sp,
+              fontWeight = FontWeight.Light,
+              modifier =
+                  Modifier.align(Alignment.Center).padding(bottom = 40.dp).testTag("noEventText"))
+        }
+      }
     }
   }
 }

--- a/app/src/main/java/com/android/streetworkapp/utils/DateUtils.kt
+++ b/app/src/main/java/com/android/streetworkapp/utils/DateUtils.kt
@@ -16,3 +16,16 @@ fun Timestamp.toFormattedString(): String {
   sdf.timeZone = TimeZone.getTimeZone("UTC") // Set to UTC to avoid timezone issues
   return sdf.format(this.toDate())
 }
+
+/**
+ * Convert a [String] of format "dd/MM/yyyy HH:mm" to a [Timestamp] object.
+ *
+ * @return The [Timestamp] object.
+ */
+fun String.toTimestamp(): Timestamp {
+  val pattern = "dd/MM/yyyy HH:mm"
+  val sdf = SimpleDateFormat(pattern, Locale.getDefault())
+  sdf.timeZone = TimeZone.getTimeZone("UTC") // Set to UTC to avoid timezone issues
+  val date = sdf.parse(this)
+  return Timestamp(date!!)
+}

--- a/app/src/test/java/com/android/streetworkapp/model/event/EventRepositoryFirestoreTest.kt
+++ b/app/src/test/java/com/android/streetworkapp/model/event/EventRepositoryFirestoreTest.kt
@@ -1,37 +1,66 @@
 package com.android.streetworkapp.model.event
 
+import android.annotation.SuppressLint
+import androidx.test.core.app.ApplicationProvider
 import com.google.android.gms.tasks.Tasks
+import com.google.firebase.FirebaseApp
 import com.google.firebase.Timestamp
 import com.google.firebase.firestore.CollectionReference
 import com.google.firebase.firestore.DocumentReference
 import com.google.firebase.firestore.DocumentSnapshot
 import com.google.firebase.firestore.FirebaseFirestore
+import com.google.firebase.firestore.QuerySnapshot
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
-import org.mockito.Mockito.mock
+import org.junit.runner.RunWith
+import org.mockito.Mock
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.`when`
+import org.mockito.MockitoAnnotations
+import org.mockito.kotlin.any
+import org.mockito.kotlin.timeout
 import org.mockito.kotlin.whenever
+import org.robolectric.RobolectricTestRunner
 
+@RunWith(RobolectricTestRunner::class)
 class EventRepositoryFirestoreTest {
 
-  private lateinit var db: FirebaseFirestore
+  @Mock private lateinit var db: FirebaseFirestore
+  @Mock private lateinit var collection: CollectionReference
+  @Mock private lateinit var documentRef: DocumentReference
+  @Mock private lateinit var document: DocumentSnapshot
+  @Mock private lateinit var query: QuerySnapshot
+
   private lateinit var eventRepository: EventRepositoryFirestore
-  private lateinit var collection: CollectionReference
-  private lateinit var documentRef: DocumentReference
-  private lateinit var document: DocumentSnapshot
+  private lateinit var event: Event
 
   @Before
   fun setUp() {
-    db = mock(FirebaseFirestore::class.java)
+
+    MockitoAnnotations.openMocks(this)
+
+    // Initialize Firebase if necessary
+    if (FirebaseApp.getApps(ApplicationProvider.getApplicationContext()).isEmpty()) {
+      FirebaseApp.initializeApp(ApplicationProvider.getApplicationContext())
+    }
+
     eventRepository = EventRepositoryFirestore(db)
-    collection = mock()
-    documentRef = mock()
-    document = mock()
+    event =
+      Event(
+        eid = "1",
+        title = "Group workout",
+        description = "A fun group workout session to train new skills",
+        participants = 3,
+        maxParticipants = 5,
+        date = Timestamp(0, 0), // 01/01/1970 00:00
+        owner = "user123")
 
     whenever(db.collection("events")).thenReturn(collection)
+    `when`(db.collection(any())).thenReturn(collection)
+    `when`(collection.document(any())).thenReturn(documentRef)
+    `when`(collection.document()).thenReturn(documentRef)
   }
 
   @Test
@@ -45,20 +74,29 @@ class EventRepositoryFirestoreTest {
 
   @Test
   fun addEventAddsEventSuccessfully() = runTest {
-    val event =
-        Event(
-            eid = "1",
-            title = "Group workout",
-            description = "A fun group workout session to train new skills",
-            participants = 3,
-            maxParticipants = 5,
-            date = Timestamp(0, 0), // 01/01/1970 00:00
-            owner = "user123")
-
     `when`(collection.document(event.eid)).thenReturn(documentRef)
     `when`(documentRef.set(event.eid)).thenReturn(Tasks.forResult(null))
 
     eventRepository.addEvent(event)
     verify(documentRef).set(event)
+  }
+
+  @SuppressLint("CheckResult")
+  @Test
+  fun getEvents_calls_collection_get() {
+    // Ensure that mockToDoQuerySnapshot is properly initialized and mocked
+    `when`(collection.get()).thenReturn(Tasks.forResult(query))
+
+
+    // Ensure the QuerySnapshot returns a list of mock DocumentSnapshots
+    `when`(query.documents).thenReturn(listOf())
+
+    val onSuccess: (List<Event>) -> Unit = {}
+    val onFailure: (Exception) -> Unit = {}
+    eventRepository.getEvents(onSuccess, onFailure)
+
+    // Verify that the 'documents' field was accessed
+    org.mockito.kotlin.verify(timeout(100)) { (query).documents }
+    verify(collection).get()
   }
 }

--- a/app/src/test/java/com/android/streetworkapp/model/event/EventRepositoryFirestoreTest.kt
+++ b/app/src/test/java/com/android/streetworkapp/model/event/EventRepositoryFirestoreTest.kt
@@ -48,14 +48,14 @@ class EventRepositoryFirestoreTest {
 
     eventRepository = EventRepositoryFirestore(db)
     event =
-      Event(
-        eid = "1",
-        title = "Group workout",
-        description = "A fun group workout session to train new skills",
-        participants = 3,
-        maxParticipants = 5,
-        date = Timestamp(0, 0), // 01/01/1970 00:00
-        owner = "user123")
+        Event(
+            eid = "1",
+            title = "Group workout",
+            description = "A fun group workout session to train new skills",
+            participants = 3,
+            maxParticipants = 5,
+            date = Timestamp(0, 0), // 01/01/1970 00:00
+            owner = "user123")
 
     whenever(db.collection("events")).thenReturn(collection)
     `when`(db.collection(any())).thenReturn(collection)
@@ -86,7 +86,6 @@ class EventRepositoryFirestoreTest {
   fun getEvents_calls_collection_get() {
     // Ensure that mockToDoQuerySnapshot is properly initialized and mocked
     `when`(collection.get()).thenReturn(Tasks.forResult(query))
-
 
     // Ensure the QuerySnapshot returns a list of mock DocumentSnapshots
     `when`(query.documents).thenReturn(listOf())

--- a/app/src/test/java/com/android/streetworkapp/model/event/EventViewModelTest.kt
+++ b/app/src/test/java/com/android/streetworkapp/model/event/EventViewModelTest.kt
@@ -10,6 +10,7 @@ import org.junit.Before
 import org.junit.Test
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.verify
+import org.mockito.kotlin.any
 
 class EventViewModelTest {
 
@@ -39,5 +40,12 @@ class EventViewModelTest {
     eventViewModel.addEvent(event)
     testDispatcher.scheduler.advanceUntilIdle()
     verify(repository).addEvent(event)
+  }
+
+  @Test
+  fun getEventsCallsRepository() = runTest {
+    eventViewModel.getEvents()
+    testDispatcher.scheduler.advanceUntilIdle()
+    verify(repository).getEvents(any(), any())
   }
 }


### PR DESCRIPTION
**Overview**
This PR aims to implement the functionalities to fetch events from the firestore database to display them from a park overview screen

**features**
- getEvents has been created in the event viewModel to fetch events from the firestore database
- an EventOverviewUistate has been created to switch between a park overview screen with no events and one with
- EventviewModel has been added as a parameter to the park overview screen
- the park overview screen has been modified to take into account the viewModel and will now display events fetched from the firestore database

**Additionnal notes**

- As the park mvvm has not been fully implemented as of this PR the viewModel will display all events stored on firebase instead of events related to a specific park, this will need to be changed later one
- the "about" button does not yet redirect to an selected event's screen, this should be handled in another branch

**testing**
To test this new feature, launch the mainactivity with map as start destination and click on a marker on the map which should redirect you the park overview screen.
If some events are stored on firebase, you should be able to see some events displayed on the screen, else you can create an event  thanks to the "create an event" button which should then be added to the list of events on the park overview screen