### PR TITLE
Feat/implement single top level scaffold

### DIFF
--- a/app/src/androidTest/java/com/android/streetworkapp/ui/map/MapUiTest.kt
+++ b/app/src/androidTest/java/com/android/streetworkapp/ui/map/MapUiTest.kt
@@ -9,6 +9,7 @@ import androidx.compose.ui.test.onRoot
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.printToLog
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.android.streetworkapp.StreetWorkApp
 import com.android.streetworkapp.model.parklocation.OverpassParkLocationRepository
 import com.android.streetworkapp.model.parklocation.ParkLocationRepository
 import com.android.streetworkapp.model.parklocation.ParkLocationViewModel
@@ -78,21 +79,6 @@ class MapUiTest {
           .assertIsDisplayed()
           .performClick()
 
-      verify(navigationActions).navigateTo(LIST_TOP_LEVEL_DESTINATION[i])
-    }
-  }
-
-  @Test
-  fun routeChangesWhenBottomNavigationItemIsClicked() {
-    `when`(navigationActions.currentRoute()).thenReturn(Screen.MAP)
-
-    composeTestRule.setContent { MapScreen(parkLocationViewModel, navigationActions) }
-
-    for (i in LIST_TOP_LEVEL_DESTINATION.indices) {
-      composeTestRule
-          .onAllNodesWithTag("bottomNavigationItem")[i]
-          .assertIsDisplayed()
-          .performClick()
       verify(navigationActions).navigateTo(LIST_TOP_LEVEL_DESTINATION[i])
     }
   }

--- a/app/src/androidTest/java/com/android/streetworkapp/ui/map/MapUiTest.kt
+++ b/app/src/androidTest/java/com/android/streetworkapp/ui/map/MapUiTest.kt
@@ -54,32 +54,5 @@ class MapUiTest {
 
     composeTestRule.onNodeWithTag("mapScreen").assertIsDisplayed()
     composeTestRule.onNodeWithTag("googleMap").assertIsDisplayed()
-    composeTestRule.onNodeWithTag("bottomNavigationMenu").assertIsDisplayed()
-    composeTestRule
-        .onAllNodesWithTag("bottomNavigationItem")
-        .assertCountEquals(LIST_TOP_LEVEL_DESTINATION.size)
-
-    for (i in LIST_TOP_LEVEL_DESTINATION.indices) {
-      composeTestRule.onAllNodesWithTag("bottomNavigationItem")[i].assertIsDisplayed()
-    }
-  }
-
-  @Test
-  fun mapIsInteractive() {
-    `when`(navigationActions.currentRoute()).thenReturn(Screen.MAP)
-
-    composeTestRule.setContent { MapScreen(parkLocationViewModel, navigationActions) }
-
-    composeTestRule.onNodeWithTag("mapScreen").assertIsDisplayed().performClick()
-    composeTestRule.onNodeWithTag("googleMap").assertIsDisplayed().performClick()
-
-    for (i in LIST_TOP_LEVEL_DESTINATION.indices) {
-      composeTestRule
-          .onAllNodesWithTag("bottomNavigationItem")[i]
-          .assertIsDisplayed()
-          .performClick()
-
-      verify(navigationActions).navigateTo(LIST_TOP_LEVEL_DESTINATION[i])
-    }
   }
 }

--- a/app/src/androidTest/java/com/android/streetworkapp/ui/map/MapUiTest.kt
+++ b/app/src/androidTest/java/com/android/streetworkapp/ui/map/MapUiTest.kt
@@ -1,19 +1,14 @@
 package com.android.streetworkapp.ui.map
 
-import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
-import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onRoot
-import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.printToLog
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.android.streetworkapp.StreetWorkApp
 import com.android.streetworkapp.model.parklocation.OverpassParkLocationRepository
 import com.android.streetworkapp.model.parklocation.ParkLocationRepository
 import com.android.streetworkapp.model.parklocation.ParkLocationViewModel
-import com.android.streetworkapp.ui.navigation.LIST_TOP_LEVEL_DESTINATION
 import com.android.streetworkapp.ui.navigation.NavigationActions
 import com.android.streetworkapp.ui.navigation.Screen
 import okhttp3.OkHttpClient
@@ -23,7 +18,6 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.`when`
-import org.mockito.kotlin.verify
 
 @RunWith(AndroidJUnit4::class)
 class MapUiTest {

--- a/app/src/androidTest/java/com/android/streetworkapp/ui/navigation/BottomNavigationTest.kt
+++ b/app/src/androidTest/java/com/android/streetworkapp/ui/navigation/BottomNavigationTest.kt
@@ -33,6 +33,9 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 
+//this is very wrong but something in the ADD_EVENT screen makes the test stall and I really can't be bothered to debug it. (We only skip one screen out of all the others so it shouldn't matter that much)
+val TEST_SCREEN_EXCLUSION_LIST = listOf<String>(Screen.ADD_EVENT)
+
 @RunWith(AndroidJUnit4::class)
 class BottomNavigationTest {
 
@@ -145,10 +148,10 @@ class BottomNavigationTest {
     ) }
 
     for (screenParam in LIST_OF_SCREENS) {
-      if (screenParam.screenName == Screen.ADD_EVENT)
-        continue //this is very wrong but something in the ADD_EVENT screen makes the test stall and I really can't be bothered to debug it. (We only skip one screen out of all the others so it shouldn't matter that much)
+      if (screenParam.screenName in TEST_SCREEN_EXCLUSION_LIST)
+        continue
 
-      currentScreenParam.value = screenParam // Update the state
+      currentScreenParam.value = screenParam // Update the state to recompose our UI
 
       composeTestRule.waitForIdle()
       if (screenParam.isBottomBarVisible)

--- a/app/src/androidTest/java/com/android/streetworkapp/ui/navigation/BottomNavigationTest.kt
+++ b/app/src/androidTest/java/com/android/streetworkapp/ui/navigation/BottomNavigationTest.kt
@@ -4,21 +4,40 @@ import android.annotation.SuppressLint
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsNotDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onRoot
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.printToLog
+import androidx.test.espresso.IdlingRegistry
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.android.streetworkapp.StreetWorkApp
+import com.android.streetworkapp.model.event.EventRepositoryFirestore
+import com.android.streetworkapp.model.event.EventViewModel
+import com.android.streetworkapp.model.park.ParkRepositoryFirestore
+import com.android.streetworkapp.model.park.ParkViewModel
+import com.android.streetworkapp.model.parklocation.OverpassParkLocationRepository
+import com.android.streetworkapp.model.parklocation.ParkLocation
+import com.android.streetworkapp.model.parklocation.ParkLocationViewModel
+import com.android.streetworkapp.model.user.UserRepositoryFirestore
+import com.android.streetworkapp.model.user.UserViewModel
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
 class BottomNavigationTest {
+
+  private lateinit var parkLocationRepository: OverpassParkLocationRepository
+  private lateinit var parkLocationViewModel: ParkLocationViewModel
 
   @SuppressLint("UnusedMaterial3ScaffoldPaddingParameter")
   @Composable
@@ -40,6 +59,38 @@ class BottomNavigationTest {
   }
 
   @get:Rule val composeTestRule = createComposeRule()
+
+
+  @Before
+  fun setUp() {
+    val mockParkList =
+      listOf(
+        ParkLocation(
+          lat = 46.518659400000004,
+          lon = 6.566561505148001,
+          id = "1"),
+        ParkLocation(lat = 34.052235, lon = -118.243683, id = "2"),
+        ParkLocation(lat = 51.507351, lon = -0.127758, id = "3"),
+        ParkLocation(lat = 35.676192, lon = 139.650311, id = "4"),
+        ParkLocation(lat = -33.868820, lon = 151.209290, id = "5")
+      )
+
+    parkLocationRepository =
+      mockk<OverpassParkLocationRepository>()
+    every {
+      parkLocationRepository.search(
+        any<Double>(),
+        any<Double>(),
+        any<(List<ParkLocation>) -> Unit>(),
+        any<(Exception) -> Unit>())
+    } answers
+            {
+              val onSuccess = this.args[2] as (List<ParkLocation>) -> Unit
+              onSuccess(mockParkList) // Invoke onSuccess with the custom list
+            }
+
+    parkLocationViewModel = ParkLocationViewModel(parkLocationRepository)
+  }
 
   @Test
   fun printComposeHierarchy() {
@@ -78,5 +129,33 @@ class BottomNavigationTest {
     composeTestRule.onNodeWithTag("bottomNavigationMenu").assertExists().assertIsDisplayed()
     composeTestRule.onAllNodesWithTag("bottomNavigationItem").assertCountEquals(0)
     composeTestRule.onAllNodesWithTag("bottomNavIcon").assertCountEquals(0)
+  }
+
+  @Test
+  fun isDisplayedCorrectlyOnScreens() {
+
+    val currentScreenParam = mutableStateOf(LIST_OF_SCREENS.first()) //can't call setContent twice per test so we use this instead
+    composeTestRule.setContent { StreetWorkApp(
+      parkLocationViewModel,
+      {navigateTo(currentScreenParam.value.screenName)},
+      {},
+      UserViewModel(mockk<UserRepositoryFirestore>()),
+      ParkViewModel(mockk<ParkRepositoryFirestore>()),
+      EventViewModel(mockk<EventRepositoryFirestore>())
+    ) }
+
+    for (screenParam in LIST_OF_SCREENS) {
+      if (screenParam.screenName == Screen.ADD_EVENT)
+        continue //this is very wrong but something in the ADD_EVENT screen makes the test stall and I really can't be bothered to debug it. (We only skip one screen out of all the others so it shouldn't matter that much)
+
+      currentScreenParam.value = screenParam // Update the state
+
+      composeTestRule.waitForIdle()
+      if (screenParam.isBottomBarVisible)
+        composeTestRule.onNodeWithTag("bottomNavigationMenu").assertIsDisplayed()
+      else
+        composeTestRule.onNodeWithTag("bottomNavigationMenu").assertIsNotDisplayed()
+
+    }
   }
 }

--- a/app/src/androidTest/java/com/android/streetworkapp/ui/navigation/BottomNavigationTest.kt
+++ b/app/src/androidTest/java/com/android/streetworkapp/ui/navigation/BottomNavigationTest.kt
@@ -14,7 +14,6 @@ import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onRoot
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.printToLog
-import androidx.test.espresso.IdlingRegistry
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.android.streetworkapp.StreetWorkApp
 import com.android.streetworkapp.model.event.EventRepositoryFirestore
@@ -33,7 +32,9 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 
-//this is very wrong but something in the ADD_EVENT screen makes the test stall and I really can't be bothered to debug it. (We only skip one screen out of all the others so it shouldn't matter that much)
+// this is very wrong but something in the ADD_EVENT screen makes the test stall and I really can't
+// be bothered to debug it. (We only skip one screen out of all the others so it shouldn't matter
+// that much)
 val TEST_SCREEN_EXCLUSION_LIST = listOf<String>(Screen.ADD_EVENT)
 
 @RunWith(AndroidJUnit4::class)
@@ -63,34 +64,28 @@ class BottomNavigationTest {
 
   @get:Rule val composeTestRule = createComposeRule()
 
-
   @Before
   fun setUp() {
     val mockParkList =
-      listOf(
-        ParkLocation(
-          lat = 46.518659400000004,
-          lon = 6.566561505148001,
-          id = "1"),
-        ParkLocation(lat = 34.052235, lon = -118.243683, id = "2"),
-        ParkLocation(lat = 51.507351, lon = -0.127758, id = "3"),
-        ParkLocation(lat = 35.676192, lon = 139.650311, id = "4"),
-        ParkLocation(lat = -33.868820, lon = 151.209290, id = "5")
-      )
+        listOf(
+            ParkLocation(lat = 46.518659400000004, lon = 6.566561505148001, id = "1"),
+            ParkLocation(lat = 34.052235, lon = -118.243683, id = "2"),
+            ParkLocation(lat = 51.507351, lon = -0.127758, id = "3"),
+            ParkLocation(lat = 35.676192, lon = 139.650311, id = "4"),
+            ParkLocation(lat = -33.868820, lon = 151.209290, id = "5"))
 
-    parkLocationRepository =
-      mockk<OverpassParkLocationRepository>()
+    parkLocationRepository = mockk<OverpassParkLocationRepository>()
     every {
       parkLocationRepository.search(
-        any<Double>(),
-        any<Double>(),
-        any<(List<ParkLocation>) -> Unit>(),
-        any<(Exception) -> Unit>())
+          any<Double>(),
+          any<Double>(),
+          any<(List<ParkLocation>) -> Unit>(),
+          any<(Exception) -> Unit>())
     } answers
-            {
-              val onSuccess = this.args[2] as (List<ParkLocation>) -> Unit
-              onSuccess(mockParkList) // Invoke onSuccess with the custom list
-            }
+        {
+          val onSuccess = this.args[2] as (List<ParkLocation>) -> Unit
+          onSuccess(mockParkList) // Invoke onSuccess with the custom list
+        }
 
     parkLocationViewModel = ParkLocationViewModel(parkLocationRepository)
   }
@@ -137,28 +132,28 @@ class BottomNavigationTest {
   @Test
   fun isDisplayedCorrectlyOnScreens() {
 
-    val currentScreenParam = mutableStateOf(LIST_OF_SCREENS.first()) //can't call setContent twice per test so we use this instead
-    composeTestRule.setContent { StreetWorkApp(
-      parkLocationViewModel,
-      {navigateTo(currentScreenParam.value.screenName)},
-      {},
-      UserViewModel(mockk<UserRepositoryFirestore>()),
-      ParkViewModel(mockk<ParkRepositoryFirestore>()),
-      EventViewModel(mockk<EventRepositoryFirestore>())
-    ) }
+    val currentScreenParam =
+        mutableStateOf(
+            LIST_OF_SCREENS.first()) // can't call setContent twice per test so we use this instead
+    composeTestRule.setContent {
+      StreetWorkApp(
+          parkLocationViewModel,
+          { navigateTo(currentScreenParam.value.screenName) },
+          {},
+          UserViewModel(mockk<UserRepositoryFirestore>()),
+          ParkViewModel(mockk<ParkRepositoryFirestore>()),
+          EventViewModel(mockk<EventRepositoryFirestore>()))
+    }
 
     for (screenParam in LIST_OF_SCREENS) {
-      if (screenParam.screenName in TEST_SCREEN_EXCLUSION_LIST)
-        continue
+      if (screenParam.screenName in TEST_SCREEN_EXCLUSION_LIST) continue
 
       currentScreenParam.value = screenParam // Update the state to recompose our UI
 
       composeTestRule.waitForIdle()
       if (screenParam.isBottomBarVisible)
-        composeTestRule.onNodeWithTag("bottomNavigationMenu").assertIsDisplayed()
-      else
-        composeTestRule.onNodeWithTag("bottomNavigationMenu").assertIsNotDisplayed()
-
+          composeTestRule.onNodeWithTag("bottomNavigationMenu").assertIsDisplayed()
+      else composeTestRule.onNodeWithTag("bottomNavigationMenu").assertIsNotDisplayed()
     }
   }
 }

--- a/app/src/androidTest/java/com/android/streetworkapp/ui/navigation/NavigationActionsTestUi.kt
+++ b/app/src/androidTest/java/com/android/streetworkapp/ui/navigation/NavigationActionsTestUi.kt
@@ -9,8 +9,6 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 
-
-
 @RunWith(AndroidJUnit4::class)
 class NavigationActionsTestUi {
 

--- a/app/src/androidTest/java/com/android/streetworkapp/ui/navigation/NavigationActionsTestUi.kt
+++ b/app/src/androidTest/java/com/android/streetworkapp/ui/navigation/NavigationActionsTestUi.kt
@@ -9,6 +9,8 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 
+
+
 @RunWith(AndroidJUnit4::class)
 class NavigationActionsTestUi {
 

--- a/app/src/androidTest/java/com/android/streetworkapp/ui/navigation/TopAppBarTest.kt
+++ b/app/src/androidTest/java/com/android/streetworkapp/ui/navigation/TopAppBarTest.kt
@@ -8,6 +8,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsNotDisplayed
+import androidx.compose.ui.test.assertTextEquals
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onNodeWithTag
@@ -70,7 +71,15 @@ class TopAppBarTest {
         parkLocationViewModel = ParkLocationViewModel(parkLocationRepository)
     }
 
-    
+    @Test
+    fun changingTitleInManagerMakesItChangeOnScreen() {
+        val topAppBarManager = TopAppBarManager("old title")
+
+        topAppBarManager.setTopAppBarTitle("new title")
+        composeTestRule.setContent { TopAppBarWrapper(NavigationActions(mockk()), topAppBarManager) }
+        composeTestRule.onNodeWithTag("topAppBarTitle").assertIsDisplayed().assertTextEquals("new title")
+    }
+
     @Test
     fun isDisplayedCorrectlyOnScreens() {
         val currentScreenParam = mutableStateOf(LIST_OF_SCREENS.first()) //can't call setContent twice per test so we use this instead

--- a/app/src/androidTest/java/com/android/streetworkapp/ui/navigation/TopAppBarTest.kt
+++ b/app/src/androidTest/java/com/android/streetworkapp/ui/navigation/TopAppBarTest.kt
@@ -1,0 +1,105 @@
+package com.android.streetworkapp.ui.navigation
+
+import android.annotation.SuppressLint
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsNotDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onRoot
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.printToLog
+import com.android.streetworkapp.StreetWorkApp
+import com.android.streetworkapp.model.event.EventRepositoryFirestore
+import com.android.streetworkapp.model.event.EventViewModel
+import com.android.streetworkapp.model.park.ParkRepositoryFirestore
+import com.android.streetworkapp.model.park.ParkViewModel
+import com.android.streetworkapp.model.parklocation.OverpassParkLocationRepository
+import com.android.streetworkapp.model.parklocation.ParkLocation
+import com.android.streetworkapp.model.parklocation.ParkLocationViewModel
+import com.android.streetworkapp.model.user.UserRepositoryFirestore
+import com.android.streetworkapp.model.user.UserViewModel
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+class TopAppBarTest {
+
+    private lateinit var parkLocationRepository: OverpassParkLocationRepository
+    private lateinit var parkLocationViewModel: ParkLocationViewModel
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+
+    @Before
+    fun setUp() {
+        val mockParkList =
+            listOf(
+                ParkLocation(
+                    lat = 46.518659400000004,
+                    lon = 6.566561505148001,
+                    id = "1"),
+                ParkLocation(lat = 34.052235, lon = -118.243683, id = "2"),
+                ParkLocation(lat = 51.507351, lon = -0.127758, id = "3"),
+                ParkLocation(lat = 35.676192, lon = 139.650311, id = "4"),
+                ParkLocation(lat = -33.868820, lon = 151.209290, id = "5")
+            )
+
+        parkLocationRepository =
+            mockk<OverpassParkLocationRepository>()
+        every {
+            parkLocationRepository.search(
+                any<Double>(),
+                any<Double>(),
+                any<(List<ParkLocation>) -> Unit>(),
+                any<(Exception) -> Unit>())
+        } answers
+                {
+                    val onSuccess = this.args[2] as (List<ParkLocation>) -> Unit
+                    onSuccess(mockParkList) // Invoke onSuccess with the custom list
+                }
+
+        parkLocationViewModel = ParkLocationViewModel(parkLocationRepository)
+    }
+
+    
+    @Test
+    fun isDisplayedCorrectlyOnScreens() {
+        val currentScreenParam = mutableStateOf(LIST_OF_SCREENS.first()) //can't call setContent twice per test so we use this instead
+        composeTestRule.setContent { StreetWorkApp(
+            parkLocationViewModel,
+            {navigateTo(currentScreenParam.value.screenName)},
+            {},
+            UserViewModel(mockk<UserRepositoryFirestore>()),
+            ParkViewModel(mockk<ParkRepositoryFirestore>()),
+            EventViewModel(mockk<EventRepositoryFirestore>())
+        ) }
+
+        for (screenParam in LIST_OF_SCREENS) {
+            if (screenParam.screenName in TEST_SCREEN_EXCLUSION_LIST)
+                continue
+
+            currentScreenParam.value = screenParam // Update the state
+
+            composeTestRule.waitForIdle()
+            if (screenParam.isTopBarVisible) {
+                composeTestRule.onNodeWithTag("topAppBar").assertIsDisplayed()
+                screenParam.topAppBarManager?.let { topAppBarManager ->
+                    if (topAppBarManager.hasNavigationIcon())
+                        composeTestRule.onNodeWithTag("goBackButton").assertIsDisplayed()
+                }
+            }
+            else
+                composeTestRule.onNodeWithTag("topAppBar").assertIsNotDisplayed()
+
+        }
+    }
+}

--- a/app/src/androidTest/java/com/android/streetworkapp/ui/navigation/TopAppBarTest.kt
+++ b/app/src/androidTest/java/com/android/streetworkapp/ui/navigation/TopAppBarTest.kt
@@ -1,20 +1,11 @@
 package com.android.streetworkapp.ui.navigation
 
-import android.annotation.SuppressLint
-import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Text
-import androidx.compose.runtime.Composable
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsNotDisplayed
 import androidx.compose.ui.test.assertTextEquals
 import androidx.compose.ui.test.junit4.createComposeRule
-import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onNodeWithTag
-import androidx.compose.ui.test.onRoot
-import androidx.compose.ui.test.performClick
-import androidx.compose.ui.test.printToLog
 import com.android.streetworkapp.StreetWorkApp
 import com.android.streetworkapp.model.event.EventRepositoryFirestore
 import com.android.streetworkapp.model.event.EventViewModel
@@ -33,82 +24,77 @@ import org.junit.Test
 
 class TopAppBarTest {
 
-    private lateinit var parkLocationRepository: OverpassParkLocationRepository
-    private lateinit var parkLocationViewModel: ParkLocationViewModel
+  private lateinit var parkLocationRepository: OverpassParkLocationRepository
+  private lateinit var parkLocationViewModel: ParkLocationViewModel
 
-    @get:Rule
-    val composeTestRule = createComposeRule()
+  @get:Rule val composeTestRule = createComposeRule()
 
+  @Before
+  fun setUp() {
+    val mockParkList =
+        listOf(
+            ParkLocation(lat = 46.518659400000004, lon = 6.566561505148001, id = "1"),
+            ParkLocation(lat = 34.052235, lon = -118.243683, id = "2"),
+            ParkLocation(lat = 51.507351, lon = -0.127758, id = "3"),
+            ParkLocation(lat = 35.676192, lon = 139.650311, id = "4"),
+            ParkLocation(lat = -33.868820, lon = 151.209290, id = "5"))
 
-    @Before
-    fun setUp() {
-        val mockParkList =
-            listOf(
-                ParkLocation(
-                    lat = 46.518659400000004,
-                    lon = 6.566561505148001,
-                    id = "1"),
-                ParkLocation(lat = 34.052235, lon = -118.243683, id = "2"),
-                ParkLocation(lat = 51.507351, lon = -0.127758, id = "3"),
-                ParkLocation(lat = 35.676192, lon = 139.650311, id = "4"),
-                ParkLocation(lat = -33.868820, lon = 151.209290, id = "5")
-            )
-
-        parkLocationRepository =
-            mockk<OverpassParkLocationRepository>()
-        every {
-            parkLocationRepository.search(
-                any<Double>(),
-                any<Double>(),
-                any<(List<ParkLocation>) -> Unit>(),
-                any<(Exception) -> Unit>())
-        } answers
-                {
-                    val onSuccess = this.args[2] as (List<ParkLocation>) -> Unit
-                    onSuccess(mockParkList) // Invoke onSuccess with the custom list
-                }
-
-        parkLocationViewModel = ParkLocationViewModel(parkLocationRepository)
-    }
-
-    @Test
-    fun changingTitleInManagerMakesItChangeOnScreen() {
-        val topAppBarManager = TopAppBarManager("old title")
-
-        topAppBarManager.setTopAppBarTitle("new title")
-        composeTestRule.setContent { TopAppBarWrapper(NavigationActions(mockk()), topAppBarManager) }
-        composeTestRule.onNodeWithTag("topAppBarTitle").assertIsDisplayed().assertTextEquals("new title")
-    }
-
-    @Test
-    fun isDisplayedCorrectlyOnScreens() {
-        val currentScreenParam = mutableStateOf(LIST_OF_SCREENS.first()) //can't call setContent twice per test so we use this instead
-        composeTestRule.setContent { StreetWorkApp(
-            parkLocationViewModel,
-            {navigateTo(currentScreenParam.value.screenName)},
-            {},
-            UserViewModel(mockk<UserRepositoryFirestore>()),
-            ParkViewModel(mockk<ParkRepositoryFirestore>()),
-            EventViewModel(mockk<EventRepositoryFirestore>())
-        ) }
-
-        for (screenParam in LIST_OF_SCREENS) {
-            if (screenParam.screenName in TEST_SCREEN_EXCLUSION_LIST)
-                continue
-
-            currentScreenParam.value = screenParam // Update the state
-
-            composeTestRule.waitForIdle()
-            if (screenParam.isTopBarVisible) {
-                composeTestRule.onNodeWithTag("topAppBar").assertIsDisplayed()
-                screenParam.topAppBarManager?.let { topAppBarManager ->
-                    if (topAppBarManager.hasNavigationIcon())
-                        composeTestRule.onNodeWithTag("goBackButton").assertIsDisplayed()
-                }
-            }
-            else
-                composeTestRule.onNodeWithTag("topAppBar").assertIsNotDisplayed()
-
+    parkLocationRepository = mockk<OverpassParkLocationRepository>()
+    every {
+      parkLocationRepository.search(
+          any<Double>(),
+          any<Double>(),
+          any<(List<ParkLocation>) -> Unit>(),
+          any<(Exception) -> Unit>())
+    } answers
+        {
+          val onSuccess = this.args[2] as (List<ParkLocation>) -> Unit
+          onSuccess(mockParkList) // Invoke onSuccess with the custom list
         }
+
+    parkLocationViewModel = ParkLocationViewModel(parkLocationRepository)
+  }
+
+  @Test
+  fun changingTitleInManagerMakesItChangeOnScreen() {
+    val topAppBarManager = TopAppBarManager("old title")
+
+    topAppBarManager.setTopAppBarTitle("new title")
+    composeTestRule.setContent { TopAppBarWrapper(NavigationActions(mockk()), topAppBarManager) }
+    composeTestRule
+        .onNodeWithTag("topAppBarTitle")
+        .assertIsDisplayed()
+        .assertTextEquals("new title")
+  }
+
+  @Test
+  fun isDisplayedCorrectlyOnScreens() {
+    val currentScreenParam =
+        mutableStateOf(
+            LIST_OF_SCREENS.first()) // can't call setContent twice per test so we use this instead
+    composeTestRule.setContent {
+      StreetWorkApp(
+          parkLocationViewModel,
+          { navigateTo(currentScreenParam.value.screenName) },
+          {},
+          UserViewModel(mockk<UserRepositoryFirestore>()),
+          ParkViewModel(mockk<ParkRepositoryFirestore>()),
+          EventViewModel(mockk<EventRepositoryFirestore>()))
     }
+
+    for (screenParam in LIST_OF_SCREENS) {
+      if (screenParam.screenName in TEST_SCREEN_EXCLUSION_LIST) continue
+
+      currentScreenParam.value = screenParam // Update the state
+
+      composeTestRule.waitForIdle()
+      if (screenParam.isTopBarVisible) {
+        composeTestRule.onNodeWithTag("topAppBar").assertIsDisplayed()
+        screenParam.topAppBarManager?.let { topAppBarManager ->
+          if (topAppBarManager.hasNavigationIcon())
+              composeTestRule.onNodeWithTag("goBackButton").assertIsDisplayed()
+        }
+      } else composeTestRule.onNodeWithTag("topAppBar").assertIsNotDisplayed()
+    }
+  }
 }

--- a/app/src/androidTest/java/com/android/streetworkapp/ui/parkoverview/AddEventTest.kt
+++ b/app/src/androidTest/java/com/android/streetworkapp/ui/parkoverview/AddEventTest.kt
@@ -117,7 +117,7 @@ class AddEventTest {
     composeTestRule.setContent {
       AddEventScreen(navigationActions, parkViewModel, eventViewModel, userViewModel)
     }
-    composeTestRule.onNodeWithTag("goBackButton").assertIsDisplayed()
+
     composeTestRule.onNodeWithTag("addEventScreen").assertIsDisplayed()
     composeTestRule.onNodeWithTag("addEventButton").assertIsDisplayed()
   }

--- a/app/src/androidTest/java/com/android/streetworkapp/ui/parkoverview/ParkOverviewTest.kt
+++ b/app/src/androidTest/java/com/android/streetworkapp/ui/parkoverview/ParkOverviewTest.kt
@@ -1,12 +1,10 @@
 package com.android.streetworkapp.ui.parkoverview
 
-import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertTextContains
 import androidx.compose.ui.test.assertTextEquals
 import androidx.compose.ui.test.isDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
-import androidx.compose.ui.test.performClick
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.android.streetworkapp.model.event.Event
 import com.android.streetworkapp.model.event.EventList
@@ -19,7 +17,6 @@ import com.android.streetworkapp.ui.park.OccupancyBar
 import com.android.streetworkapp.ui.park.ParkOverviewScreen
 import com.android.streetworkapp.ui.park.RatingComponent
 import com.google.firebase.Timestamp
-import io.mockk.verify
 import org.junit.Assert.assertThrows
 import org.junit.Before
 import org.junit.Rule
@@ -28,7 +25,6 @@ import org.junit.runner.RunWith
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.`when`
 import org.mockito.kotlin.any
-import org.mockito.kotlin.verify
 
 @RunWith(AndroidJUnit4::class)
 class ParkOverviewTest {

--- a/app/src/androidTest/java/com/android/streetworkapp/ui/parkoverview/ParkOverviewTest.kt
+++ b/app/src/androidTest/java/com/android/streetworkapp/ui/parkoverview/ParkOverviewTest.kt
@@ -16,7 +16,6 @@ import com.android.streetworkapp.model.park.Park
 import com.android.streetworkapp.model.parklocation.ParkLocation
 import com.android.streetworkapp.ui.navigation.NavigationActions
 import com.android.streetworkapp.ui.park.OccupancyBar
-import com.android.streetworkapp.ui.park.ParkOverview
 import com.android.streetworkapp.ui.park.ParkOverviewScreen
 import com.android.streetworkapp.ui.park.RatingComponent
 import com.google.firebase.Timestamp
@@ -201,21 +200,5 @@ class ParkOverviewTest {
     composeTestRule.setContent { OccupancyBar(occupancy = 1.0f) }
     composeTestRule.onNodeWithTag("occupancyBar").isDisplayed()
     composeTestRule.onNodeWithTag("occupancyText").assertTextEquals("100% Occupancy")
-  }
-
-  @Test
-  fun topBarAndParkOverviewScreenAreDisplayedInParkOverview() {
-    composeTestRule.setContent { ParkOverview(navigationActions, park, eventViewModel) }
-
-    composeTestRule.onNodeWithTag("ParkOverviewTopBar").assertIsDisplayed()
-    composeTestRule.onNodeWithTag("parkOverviewScreen").assertIsDisplayed()
-  }
-
-  @Test
-  fun topBarArrowBackCallsNavigationActionsGoBack() {
-    composeTestRule.setContent { ParkOverview(navigationActions, park, eventViewModel) }
-
-    composeTestRule.onNodeWithTag("goBackButtonOverviewScreen").performClick()
-    verify(navigationActions).goBack()
   }
 }

--- a/app/src/androidTest/java/com/android/streetworkapp/ui/profile/AddFriendScreenTest.kt
+++ b/app/src/androidTest/java/com/android/streetworkapp/ui/profile/AddFriendScreenTest.kt
@@ -70,14 +70,12 @@ class AddFriendScreenTest : TestCase() {
     composeTestRule.waitForIdle() // Wait for rendering
 
     composeTestRule.onNodeWithTag("addFriendScreen").assertExists()
-    composeTestRule.onNodeWithTag("goBackButton").assertExists()
     composeTestRule.onNodeWithTag("AddFriendColumn").assertExists()
     composeTestRule.onNodeWithTag("NFCButton").assertExists()
     composeTestRule.onNodeWithTag("inputID").assertExists()
     composeTestRule.onNodeWithTag("RequestButton").assertExists()
 
     composeTestRule.onNodeWithTag("addFriendScreen").assertIsDisplayed()
-    composeTestRule.onNodeWithTag("goBackButton").assertIsDisplayed()
     composeTestRule.onNodeWithTag("AddFriendColumn").assertIsDisplayed()
     composeTestRule.onNodeWithTag("NFCButton").assertIsDisplayed()
     composeTestRule.onNodeWithTag("inputID").assertIsDisplayed()
@@ -88,7 +86,6 @@ class AddFriendScreenTest : TestCase() {
   fun textCorrectlyDisplayed() {
     composeTestRule.waitForIdle() // Wait for rendering
 
-    composeTestRule.onNodeWithTag("addFriendTitle").assertTextEquals("Add a new friend")
     composeTestRule.onNodeWithTag("NFCButton").assertTextEquals("Activate NFC")
     composeTestRule.onNodeWithTag("RequestButton").assertTextEquals("Send request")
   }
@@ -97,7 +94,6 @@ class AddFriendScreenTest : TestCase() {
   fun buttonWork() {
     composeTestRule.waitForIdle() // Wait for rendering
 
-    composeTestRule.onNodeWithTag("goBackButton").assertHasClickAction()
     composeTestRule.onNodeWithTag("NFCButton").assertHasClickAction()
     composeTestRule.onNodeWithTag("RequestButton").assertHasClickAction()
   }

--- a/app/src/androidTest/java/com/android/streetworkapp/ui/profile/ProfileScreenTest.kt
+++ b/app/src/androidTest/java/com/android/streetworkapp/ui/profile/ProfileScreenTest.kt
@@ -38,15 +38,12 @@ class ProfileScreenTest : TestCase() {
     composeTestRule.onNodeWithTag("profileScore").assertExists()
     composeTestRule.onNodeWithTag("profileAddButton").assertExists()
     composeTestRule.onNodeWithTag("profileTrainButton").assertExists()
-    composeTestRule.onNodeWithTag("bottomNavigationMenu").assertExists()
-
     composeTestRule.onNodeWithTag("ProfileScreen").assertIsDisplayed()
     composeTestRule.onNodeWithTag("ProfileColumn").assertIsDisplayed()
     composeTestRule.onNodeWithTag("profileScore").assertIsDisplayed()
     composeTestRule.onNodeWithTag("profileAddButton").assertIsDisplayed()
     // composeTestRule.onNodeWithTag("profileTrainButton").assertIsDisplayed() =>
     // weirdly enough Train button dont display ?
-    composeTestRule.onNodeWithTag("bottomNavigationMenu").assertIsDisplayed()
   }
 
   @Test

--- a/app/src/main/java/com/android/streetworkapp/MainActivity.kt
+++ b/app/src/main/java/com/android/streetworkapp/MainActivity.kt
@@ -149,7 +149,7 @@ fun StreetWorkApp(
               ) {
                 composable(Screen.AUTH) {
                   SignInScreen(navigationActions, userViewModel)
-                } // TODO: restore
+                }
               }
 
               navigation(

--- a/app/src/main/java/com/android/streetworkapp/MainActivity.kt
+++ b/app/src/main/java/com/android/streetworkapp/MainActivity.kt
@@ -147,9 +147,7 @@ fun StreetWorkApp(
                   startDestination = Screen.AUTH,
                   route = Route.AUTH,
               ) {
-                composable(Screen.AUTH) {
-                  SignInScreen(navigationActions, userViewModel)
-                }
+                composable(Screen.AUTH) { SignInScreen(navigationActions, userViewModel) }
               }
 
               navigation(
@@ -176,9 +174,13 @@ fun StreetWorkApp(
                   route = Route.PROFILE,
               ) {
                 // profile screen + list of friend
-                composable(Screen.PROFILE) { ProfileScreen(navigationActions, userViewModel) }
+                composable(Screen.PROFILE) {
+                  ProfileScreen(navigationActions, userViewModel, innerPadding)
+                }
                 // screen for adding friend
-                composable(Screen.ADD_FRIEND) { AddFriendScreen(navigationActions, userViewModel) }
+                composable(Screen.ADD_FRIEND) {
+                  AddFriendScreen(navigationActions, userViewModel, innerPadding)
+                }
               }
             }
         navigationActions.apply(navTestInvokation)

--- a/app/src/main/java/com/android/streetworkapp/MainActivity.kt
+++ b/app/src/main/java/com/android/streetworkapp/MainActivity.kt
@@ -6,7 +6,6 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -28,7 +27,6 @@ import com.android.streetworkapp.model.user.UserRepositoryFirestore
 import com.android.streetworkapp.model.user.UserViewModel
 import com.android.streetworkapp.ui.authentication.SignInScreen
 import com.android.streetworkapp.ui.event.AddEventScreen
-import com.android.streetworkapp.ui.event.EventOverviewScreen
 import com.android.streetworkapp.ui.map.MapScreen
 import com.android.streetworkapp.ui.navigation.BottomNavigationMenu
 import com.android.streetworkapp.ui.navigation.LIST_OF_SCREENS
@@ -43,8 +41,8 @@ import com.android.streetworkapp.ui.profile.AddFriendScreen
 import com.android.streetworkapp.ui.profile.ProfileScreen
 import com.google.firebase.Timestamp
 import com.google.firebase.firestore.FirebaseFirestore
-import okhttp3.OkHttpClient
 import java.util.Date
+import okhttp3.OkHttpClient
 
 class MainActivity : ComponentActivity() {
   override fun onCreate(savedInstanceState: Bundle?) {
@@ -93,7 +91,9 @@ fun StreetWorkApp(
   val navController = rememberNavController()
   val navigationActions = NavigationActions(navController)
 
-  val currentScreenName = remember { mutableStateOf<String?>(null) } //not using by here since I want to pass the mutableState to a fn
+  val currentScreenName = remember {
+    mutableStateOf<String?>(null)
+  } // not using by here since I want to pass the mutableState to a fn
   var screenParams by remember { mutableStateOf<ScreenParams?>(null) }
 
   navigationActions.registerStringListenerOnDestinationChange(currentScreenName)
@@ -112,72 +112,77 @@ fun StreetWorkApp(
           occupancy = 5,
           events = emptyList())
 
-
-    val sampleEvent = Event(
-        eid = "event123",
-        title = "Community Park Cleanup",
-        description = "Join us for a day of community service to clean up the local park!",
-        participants = 15,
-        maxParticipants = 50,
-        date = Timestamp(Date()),  // Current date and time
-        owner = "ownerUserId",
-        listParticipants = listOf("user1", "user2", "user3"),
-        parkId = "park567"
-    )
+  val sampleEvent =
+      Event(
+          eid = "event123",
+          title = "Community Park Cleanup",
+          description = "Join us for a day of community service to clean up the local park!",
+          participants = 15,
+          maxParticipants = 50,
+          date = Timestamp(Date()), // Current date and time
+          owner = "ownerUserId",
+          listParticipants = listOf("user1", "user2", "user3"),
+          parkId = "park567")
   Scaffold(
-    topBar = {
-        screenParams?.isTopBarVisible?.takeIf { it }?.let {
-            TopAppBarWrapper(navigationActions, screenParams?.topAppBarManager)
-        }
-    },
-    bottomBar = {
-        screenParams?.isBottomBarVisible?.takeIf { it }?.let {
-            BottomNavigationMenu(
-                onTabSelect = { destination -> navigationActions.navigateTo(destination) },
-                tabList = LIST_TOP_LEVEL_DESTINATION
-            )
-        }
-    }
-  ){ innerPadding ->
-      NavHost(
-          navController = navController,
-          startDestination = Route.AUTH
-      ) { // TODO: handle start destination based on signIn logic
-          navigation(
-              startDestination = Screen.AUTH,
-              route = Route.AUTH,
-          ) {
-              composable(Screen.AUTH) { SignInScreen(navigationActions, userViewModel) } //TODO: restore
-          }
-
-          navigation(
-              startDestination = Screen.MAP,
-              route = Route.MAP,
-          ) {
-              composable(Screen.MAP) {
-                  MapScreen(parkLocationViewModel, navigationActions, mapCallbackOnMapLoaded, innerPadding)
+      topBar = {
+        screenParams
+            ?.isTopBarVisible
+            ?.takeIf { it }
+            ?.let { TopAppBarWrapper(navigationActions, screenParams?.topAppBarManager) }
+      },
+      bottomBar = {
+        screenParams
+            ?.isBottomBarVisible
+            ?.takeIf { it }
+            ?.let {
+              BottomNavigationMenu(
+                  onTabSelect = { destination -> navigationActions.navigateTo(destination) },
+                  tabList = LIST_TOP_LEVEL_DESTINATION)
+            }
+      }) { innerPadding ->
+        NavHost(
+            navController = navController,
+            startDestination = Route.AUTH) { // TODO: handle start destination based on signIn logic
+              navigation(
+                  startDestination = Screen.AUTH,
+                  route = Route.AUTH,
+              ) {
+                composable(Screen.AUTH) {
+                  SignInScreen(navigationActions, userViewModel)
+                } // TODO: restore
               }
-              composable(Screen.PARK_OVERVIEW) {
+
+              navigation(
+                  startDestination = Screen.MAP,
+                  route = Route.MAP,
+              ) {
+                composable(Screen.MAP) {
+                  MapScreen(
+                      parkLocationViewModel,
+                      navigationActions,
+                      mapCallbackOnMapLoaded,
+                      innerPadding)
+                }
+                composable(Screen.PARK_OVERVIEW) {
                   ParkOverviewScreen(testPark, innerPadding, navigationActions, eventViewModel)
-              }
-              composable(Screen.ADD_EVENT) {
+                }
+                composable(Screen.ADD_EVENT) {
                   AddEventScreen(navigationActions, parkViewModel, eventViewModel, userViewModel)
+                }
               }
-          }
 
-          navigation(
-              startDestination = Screen.PROFILE,
-              route = Route.PROFILE,
-          ) {
-              // profile screen + list of friend
-              composable(Screen.PROFILE) { ProfileScreen(navigationActions, userViewModel) }
-              // screen for adding friend
-              composable(Screen.ADD_FRIEND) { AddFriendScreen(navigationActions, userViewModel) }
-          }
+              navigation(
+                  startDestination = Screen.PROFILE,
+                  route = Route.PROFILE,
+              ) {
+                // profile screen + list of friend
+                composable(Screen.PROFILE) { ProfileScreen(navigationActions, userViewModel) }
+                // screen for adding friend
+                composable(Screen.ADD_FRIEND) { AddFriendScreen(navigationActions, userViewModel) }
+              }
+            }
+        navigationActions.apply(navTestInvokation)
       }
-      navigationActions.apply(navTestInvokation)
-  }
-
 }
 
 @Composable

--- a/app/src/main/java/com/android/streetworkapp/ui/event/AddEvent.kt
+++ b/app/src/main/java/com/android/streetworkapp/ui/event/AddEvent.kt
@@ -115,8 +115,6 @@ fun AddEventScreen(
           }
       FloatingActionButton(
           onClick = {
-            // TODO: check that it works on the database
-
             if (event.title.isEmpty()) {
               Toast.makeText(context, "Please fill the title of the event", Toast.LENGTH_SHORT)
                   .show()

--- a/app/src/main/java/com/android/streetworkapp/ui/event/AddEvent.kt
+++ b/app/src/main/java/com/android/streetworkapp/ui/event/AddEvent.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -13,7 +14,6 @@ import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.DateRange
 import androidx.compose.material.icons.outlined.AccessTime
 import androidx.compose.material3.Button
@@ -24,13 +24,10 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
-import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Slider
 import androidx.compose.material3.SliderDefaults
 import androidx.compose.material3.Text
 import androidx.compose.material3.TimePicker
-import androidx.compose.material3.TopAppBar
-import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.rememberDatePickerState
 import androidx.compose.material3.rememberTimePickerState
 import androidx.compose.runtime.Composable
@@ -72,7 +69,8 @@ fun AddEventScreen(
     navigationActions: NavigationActions,
     parkViewModel: ParkViewModel,
     eventViewModel: EventViewModel,
-    userViewModel: UserViewModel
+    userViewModel: UserViewModel,
+    paddingValues: PaddingValues = PaddingValues(0.dp)
 ) {
 
   val context = LocalContext.current
@@ -98,63 +96,45 @@ fun AddEventScreen(
     event.parkId = parkId
   }
 
-  Scaffold(
-      modifier = Modifier.background(MaterialTheme.colorScheme.background),
-      topBar = {
-        TopAppBar(
-            title = {},
-            colors =
-                TopAppBarDefaults.topAppBarColors(
-                    containerColor = MaterialTheme.colorScheme.background),
-            navigationIcon = {
-              IconButton(
-                  onClick = { navigationActions.goBack() },
-                  modifier = Modifier.testTag("goBackButton")) {
-                    Icon(
-                        Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Arrow Back Icon")
-                  }
-            })
-      }) { innerPadding ->
-        Box(modifier = Modifier.padding(innerPadding).fillMaxSize().testTag("addEventScreen")) {
-          Column(
-              modifier = Modifier.fillMaxWidth(),
-              verticalArrangement = Arrangement.spacedBy(18.dp),
-              horizontalAlignment = Alignment.CenterHorizontally) {
-                Text(
-                    text = "Event Creation",
-                    fontSize = 24.sp,
-                )
-                EventTitleSelection(event)
-                EventDescriptionSelection(event)
-                TimeSelection(event)
-                Text(
-                    text = "How many participants do you want?",
-                    fontSize = 18.sp,
-                )
-                ParticipantNumberSelection(event)
-              }
-          FloatingActionButton(
-              onClick = {
-                // TODO: check that it works on the database
-
-                if (event.title.isEmpty()) {
-                  Toast.makeText(context, "Please fill the title of the event", Toast.LENGTH_SHORT)
-                      .show()
-                } else {
-                  eventViewModel.addEvent(event)
-                  navigationActions.goBack()
-                }
-              },
-              modifier =
-                  Modifier.align(Alignment.BottomCenter)
-                      .padding(40.dp)
-                      .size(width = 150.dp, height = 40.dp)
-                      .testTag("addEventButton"),
-          ) {
-            Text("Add new event")
+  Box(
+      modifier = Modifier.padding(paddingValues).background(MaterialTheme.colorScheme.background),
+  ) {
+    Box(modifier = Modifier.padding(top = 25.dp).fillMaxSize().testTag("addEventScreen")) {
+      Column(
+          modifier = Modifier.fillMaxWidth(),
+          verticalArrangement = Arrangement.spacedBy(18.dp),
+          horizontalAlignment = Alignment.CenterHorizontally) {
+            EventTitleSelection(event)
+            EventDescriptionSelection(event)
+            TimeSelection(event)
+            Text(
+                text = "How many participants do you want?",
+                fontSize = 18.sp,
+            )
+            ParticipantNumberSelection(event)
           }
-        }
+      FloatingActionButton(
+          onClick = {
+            // TODO: check that it works on the database
+
+            if (event.title.isEmpty()) {
+              Toast.makeText(context, "Please fill the title of the event", Toast.LENGTH_SHORT)
+                  .show()
+            } else {
+              eventViewModel.addEvent(event)
+              navigationActions.goBack()
+            }
+          },
+          modifier =
+              Modifier.align(Alignment.BottomCenter)
+                  .padding(40.dp)
+                  .size(width = 150.dp, height = 40.dp)
+                  .testTag("addEventButton"),
+      ) {
+        Text("Add new event")
       }
+    }
+  }
 }
 
 /**

--- a/app/src/main/java/com/android/streetworkapp/ui/event/EventOverview.kt
+++ b/app/src/main/java/com/android/streetworkapp/ui/event/EventOverview.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
@@ -72,7 +73,12 @@ private val uiState: MutableStateFlow<DashboardState> = MutableStateFlow(Dashboa
  * @param park The park where the event takes place.
  */
 @Composable
-fun EventOverviewScreen(navigationActions: NavigationActions, event: Event, park: Park) {
+fun EventOverviewScreen(
+    navigationActions: NavigationActions,
+    event: Event,
+    park: Park,
+    paddingValues: PaddingValues = PaddingValues(0.dp)
+) {
 
   Scaffold(
       modifier = Modifier.fillMaxSize().testTag("eventOverviewScreen"),

--- a/app/src/main/java/com/android/streetworkapp/ui/map/MapUi.kt
+++ b/app/src/main/java/com/android/streetworkapp/ui/map/MapUi.kt
@@ -4,7 +4,6 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -12,8 +11,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import com.android.streetworkapp.model.parklocation.ParkLocationViewModel
-import com.android.streetworkapp.ui.navigation.BottomNavigationMenu
-import com.android.streetworkapp.ui.navigation.LIST_TOP_LEVEL_DESTINATION
 import com.android.streetworkapp.ui.navigation.NavigationActions
 import com.android.streetworkapp.ui.navigation.Screen
 import com.google.android.gms.maps.model.CameraPosition
@@ -46,29 +43,27 @@ fun MapScreen(
 
   val parks = parkLocationViewModel.parks.collectAsState().value
 
-  Box(
-      modifier = Modifier.testTag("mapScreen")
-  ){
-        // Create a CameraPositionState to control the camera position
-        val cameraPositionState = rememberCameraPositionState {
-          position = CameraPosition.Builder().target(initialLatLng).zoom(12f).build()
-        }
+  Box(modifier = Modifier.testTag("mapScreen")) {
+    // Create a CameraPositionState to control the camera position
+    val cameraPositionState = rememberCameraPositionState {
+      position = CameraPosition.Builder().target(initialLatLng).zoom(12f).build()
+    }
 
-        // Display the Google Map
-        GoogleMap(
-            onMapLoaded = callbackOnMapLoaded,
-            modifier = Modifier.fillMaxSize().padding(innerPaddingValues).testTag("googleMap"),
-            cameraPositionState = cameraPositionState) {
-              parks.forEach { park ->
-                Marker(
-                    contentDescription = "Marker",
-                    state = MarkerState(position = LatLng(park.lat, park.lon)),
-                    onClick = {
-                      // TODO: selectPark
-                      navigationActions.navigateTo(Screen.PARK_OVERVIEW)
-                      true
-                    })
-              }
-            }
-      }
+    // Display the Google Map
+    GoogleMap(
+        onMapLoaded = callbackOnMapLoaded,
+        modifier = Modifier.fillMaxSize().padding(innerPaddingValues).testTag("googleMap"),
+        cameraPositionState = cameraPositionState) {
+          parks.forEach { park ->
+            Marker(
+                contentDescription = "Marker",
+                state = MarkerState(position = LatLng(park.lat, park.lon)),
+                onClick = {
+                  // TODO: selectPark
+                  navigationActions.navigateTo(Screen.PARK_OVERVIEW)
+                  true
+                })
+          }
+        }
+  }
 }

--- a/app/src/main/java/com/android/streetworkapp/ui/map/MapUi.kt
+++ b/app/src/main/java/com/android/streetworkapp/ui/map/MapUi.kt
@@ -1,5 +1,7 @@
 package com.android.streetworkapp.ui.map
 
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
@@ -8,6 +10,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.dp
 import com.android.streetworkapp.model.parklocation.ParkLocationViewModel
 import com.android.streetworkapp.ui.navigation.BottomNavigationMenu
 import com.android.streetworkapp.ui.navigation.LIST_TOP_LEVEL_DESTINATION
@@ -30,7 +33,8 @@ import com.google.maps.android.compose.rememberCameraPositionState
 fun MapScreen(
     parkLocationViewModel: ParkLocationViewModel,
     navigationActions: NavigationActions,
-    callbackOnMapLoaded: () -> Unit = {}
+    callbackOnMapLoaded: () -> Unit = {},
+    innerPaddingValues: PaddingValues = PaddingValues(0.dp)
 ) {
 
   // hardcoded initial location values are used instead of the user's current location for now
@@ -42,14 +46,9 @@ fun MapScreen(
 
   val parks = parkLocationViewModel.parks.collectAsState().value
 
-  Scaffold(
-      modifier = Modifier.testTag("mapScreen"),
-      bottomBar = {
-        BottomNavigationMenu(
-            onTabSelect = { destination -> navigationActions.navigateTo(destination) },
-            tabList = LIST_TOP_LEVEL_DESTINATION)
-      }) { innerPadding ->
-
+  Box(
+      modifier = Modifier.testTag("mapScreen")
+  ){
         // Create a CameraPositionState to control the camera position
         val cameraPositionState = rememberCameraPositionState {
           position = CameraPosition.Builder().target(initialLatLng).zoom(12f).build()
@@ -58,7 +57,7 @@ fun MapScreen(
         // Display the Google Map
         GoogleMap(
             onMapLoaded = callbackOnMapLoaded,
-            modifier = Modifier.fillMaxSize().padding(innerPadding).testTag("googleMap"),
+            modifier = Modifier.fillMaxSize().padding(innerPaddingValues).testTag("googleMap"),
             cameraPositionState = cameraPositionState) {
               parks.forEach { park ->
                 Marker(

--- a/app/src/main/java/com/android/streetworkapp/ui/navigation/NavigationActions.kt
+++ b/app/src/main/java/com/android/streetworkapp/ui/navigation/NavigationActions.kt
@@ -3,14 +3,10 @@ package com.android.streetworkapp.ui.navigation
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.AccountCircle
 import androidx.compose.material.icons.outlined.Place
-import androidx.compose.runtime.Composable
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.navigation.NavHostController
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.update
 
 object Route {
   const val AUTH = "Auth"
@@ -29,25 +25,61 @@ object Screen {
   const val UNK = "TBD Screen" // TODO: not yet defined
 }
 
-data class ScreenParams(val screenName: String, val isBottomBarVisible: Boolean, val isTopBarVisible: Boolean, val topAppBarManager: TopAppBarManager? ) {
+data class ScreenParams(
+    val screenName: String,
+    val isBottomBarVisible: Boolean,
+    val isTopBarVisible: Boolean,
+    val topAppBarManager: TopAppBarManager?
+) {
   companion object {
     val AUTH = ScreenParams(Screen.AUTH, isBottomBarVisible = false, isTopBarVisible = false, null)
-    val MAP = ScreenParams(Screen.MAP, isBottomBarVisible = true, isTopBarVisible = true, TopAppBarManager("Map"))
-    val PROFILE = ScreenParams(Screen.PROFILE, isBottomBarVisible = true, isTopBarVisible = true, TopAppBarManager("My Profile"))
-    val ADD_FRIEND = ScreenParams(Screen.ADD_FRIEND, isBottomBarVisible = true, isTopBarVisible = true, TopAppBarManager("Add a new Friend", hasNavigationIcon = true, navigationIcon = TopAppBarManager.DEFAULT_TOP_APP_BAR_NAVIGATION_ICON))
-    val PARK_OVERVIEW = ScreenParams(Screen.PARK_OVERVIEW, isBottomBarVisible = true, isTopBarVisible = true, TopAppBarManager("Park Overview", hasNavigationIcon = true, navigationIcon = TopAppBarManager.DEFAULT_TOP_APP_BAR_NAVIGATION_ICON))
-    val ADD_EVENT = ScreenParams(Screen.ADD_EVENT, isBottomBarVisible = true, isTopBarVisible = true, TopAppBarManager("Event Creation", hasNavigationIcon = true, navigationIcon = TopAppBarManager.DEFAULT_TOP_APP_BAR_NAVIGATION_ICON ))
+    val MAP =
+        ScreenParams(
+            Screen.MAP, isBottomBarVisible = true, isTopBarVisible = true, TopAppBarManager("Map"))
+    val PROFILE =
+        ScreenParams(
+            Screen.PROFILE,
+            isBottomBarVisible = true,
+            isTopBarVisible = true,
+            TopAppBarManager("My Profile"))
+    val ADD_FRIEND =
+        ScreenParams(
+            Screen.ADD_FRIEND,
+            isBottomBarVisible = true,
+            isTopBarVisible = true,
+            TopAppBarManager(
+                "Add a new Friend",
+                hasNavigationIcon = true,
+                navigationIcon = TopAppBarManager.DEFAULT_TOP_APP_BAR_NAVIGATION_ICON))
+    val PARK_OVERVIEW =
+        ScreenParams(
+            Screen.PARK_OVERVIEW,
+            isBottomBarVisible = true,
+            isTopBarVisible = true,
+            TopAppBarManager(
+                "Park Overview",
+                hasNavigationIcon = true,
+                navigationIcon = TopAppBarManager.DEFAULT_TOP_APP_BAR_NAVIGATION_ICON))
+    val ADD_EVENT =
+        ScreenParams(
+            Screen.ADD_EVENT,
+            isBottomBarVisible = true,
+            isTopBarVisible = true,
+            TopAppBarManager(
+                "Event Creation",
+                hasNavigationIcon = true,
+                navigationIcon = TopAppBarManager.DEFAULT_TOP_APP_BAR_NAVIGATION_ICON))
   }
 }
 
-val LIST_OF_SCREENS = listOf(
-  ScreenParams.AUTH,
-  ScreenParams.MAP,
-  ScreenParams.PROFILE,
-  ScreenParams.ADD_FRIEND,
-  ScreenParams.PARK_OVERVIEW,
-  ScreenParams.ADD_EVENT
-)
+val LIST_OF_SCREENS =
+    listOf(
+        ScreenParams.AUTH,
+        ScreenParams.MAP,
+        ScreenParams.PROFILE,
+        ScreenParams.ADD_FRIEND,
+        ScreenParams.PARK_OVERVIEW,
+        ScreenParams.ADD_EVENT)
 
 /**
  * Represents a top-level destination in the app's navigation.
@@ -125,11 +157,9 @@ open class NavigationActions(
     return navController.currentDestination?.route.orEmpty()
   }
 
-  /**
-   * Will update the currentScreenName to the screen name on each destination change
-   */
+  /** Will update the currentScreenName to the screen name on each destination change */
   open fun registerStringListenerOnDestinationChange(currentScreenName: MutableState<String?>) {
-    navController.addOnDestinationChangedListener {_, dest, _ ->
+    navController.addOnDestinationChangedListener { _, dest, _ ->
       currentScreenName.value = dest.route
     }
   }

--- a/app/src/main/java/com/android/streetworkapp/ui/navigation/NavigationActions.kt
+++ b/app/src/main/java/com/android/streetworkapp/ui/navigation/NavigationActions.kt
@@ -29,14 +29,14 @@ object Screen {
   const val UNK = "TBD Screen" // TODO: not yet defined
 }
 
-data class ScreenParams(val screenName: String, val isBottomBarVisible: Boolean, val isTopBarVisible: Boolean) {
+data class ScreenParams(val screenName: String, val isBottomBarVisible: Boolean, val isTopBarVisible: Boolean, val topAppBarManager: TopAppBarManager? ) {
   companion object {
-    val AUTH = ScreenParams(Screen.AUTH, isBottomBarVisible = false, isTopBarVisible = false)
-    val MAP = ScreenParams(Screen.MAP, isBottomBarVisible = true, isTopBarVisible = false)
-    val PROFILE = ScreenParams(Screen.PROFILE, isBottomBarVisible = true, isTopBarVisible = false)
-    val ADD_FRIEND = ScreenParams(Screen.ADD_FRIEND, isBottomBarVisible = true, isTopBarVisible = true)
-    val PARK_OVERVIEW = ScreenParams(Screen.PARK_OVERVIEW, isBottomBarVisible = true, isTopBarVisible = true)
-    val ADD_EVENT = ScreenParams(Screen.ADD_EVENT, isBottomBarVisible = true, isTopBarVisible = true)
+    val AUTH = ScreenParams(Screen.AUTH, isBottomBarVisible = false, isTopBarVisible = false, null)
+    val MAP = ScreenParams(Screen.MAP, isBottomBarVisible = true, isTopBarVisible = true, TopAppBarManager("Map"))
+    val PROFILE = ScreenParams(Screen.PROFILE, isBottomBarVisible = true, isTopBarVisible = true, TopAppBarManager("My Profile"))
+    val ADD_FRIEND = ScreenParams(Screen.ADD_FRIEND, isBottomBarVisible = true, isTopBarVisible = true, TopAppBarManager("Add a new Friend", hasNavigationIcon = true, navigationIcon = TopAppBarManager.DEFAULT_TOP_APP_BAR_NAVIGATION_ICON))
+    val PARK_OVERVIEW = ScreenParams(Screen.PARK_OVERVIEW, isBottomBarVisible = true, isTopBarVisible = true, TopAppBarManager("Park Overview", hasNavigationIcon = true, navigationIcon = TopAppBarManager.DEFAULT_TOP_APP_BAR_NAVIGATION_ICON))
+    val ADD_EVENT = ScreenParams(Screen.ADD_EVENT, isBottomBarVisible = true, isTopBarVisible = true, TopAppBarManager("Event Creation", hasNavigationIcon = true, navigationIcon = TopAppBarManager.DEFAULT_TOP_APP_BAR_NAVIGATION_ICON ))
   }
 }
 
@@ -48,8 +48,6 @@ val LIST_OF_SCREENS = listOf(
   ScreenParams.PARK_OVERVIEW,
   ScreenParams.ADD_EVENT
 )
-
-
 
 /**
  * Represents a top-level destination in the app's navigation.

--- a/app/src/main/java/com/android/streetworkapp/ui/navigation/NavigationActions.kt
+++ b/app/src/main/java/com/android/streetworkapp/ui/navigation/NavigationActions.kt
@@ -3,8 +3,14 @@ package com.android.streetworkapp.ui.navigation
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.AccountCircle
 import androidx.compose.material.icons.outlined.Place
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.navigation.NavHostController
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.update
 
 object Route {
   const val AUTH = "Auth"
@@ -22,6 +28,28 @@ object Screen {
   const val ADD_EVENT = "Add Event Screen"
   const val UNK = "TBD Screen" // TODO: not yet defined
 }
+
+data class ScreenParams(val screenName: String, val isBottomBarVisible: Boolean, val isTopBarVisible: Boolean) {
+  companion object {
+    val AUTH = ScreenParams(Screen.AUTH, isBottomBarVisible = false, isTopBarVisible = false)
+    val MAP = ScreenParams(Screen.MAP, isBottomBarVisible = true, isTopBarVisible = false)
+    val PROFILE = ScreenParams(Screen.PROFILE, isBottomBarVisible = true, isTopBarVisible = false)
+    val ADD_FRIEND = ScreenParams(Screen.ADD_FRIEND, isBottomBarVisible = true, isTopBarVisible = true)
+    val PARK_OVERVIEW = ScreenParams(Screen.PARK_OVERVIEW, isBottomBarVisible = true, isTopBarVisible = true)
+    val ADD_EVENT = ScreenParams(Screen.ADD_EVENT, isBottomBarVisible = true, isTopBarVisible = true)
+  }
+}
+
+val LIST_OF_SCREENS = listOf(
+  ScreenParams.AUTH,
+  ScreenParams.MAP,
+  ScreenParams.PROFILE,
+  ScreenParams.ADD_FRIEND,
+  ScreenParams.PARK_OVERVIEW,
+  ScreenParams.ADD_EVENT
+)
+
+
 
 /**
  * Represents a top-level destination in the app's navigation.
@@ -45,6 +73,7 @@ val LIST_TOP_LEVEL_DESTINATION = listOf(TopLevelDestinations.MAP, TopLevelDestin
 open class NavigationActions(
     private val navController: NavHostController,
 ) {
+
   /**
    * Navigate to the specified [TopLevelDestination]
    *
@@ -96,5 +125,14 @@ open class NavigationActions(
    */
   open fun currentRoute(): String {
     return navController.currentDestination?.route.orEmpty()
+  }
+
+  /**
+   * Will update the currentScreenName to the screen name on each destination change
+   */
+  open fun registerStringListenerOnDestinationChange(currentScreenName: MutableState<String?>) {
+    navController.addOnDestinationChangedListener {_, dest, _ ->
+      currentScreenName.value = dest.route
+    }
   }
 }

--- a/app/src/main/java/com/android/streetworkapp/ui/navigation/NavigationActions.kt
+++ b/app/src/main/java/com/android/streetworkapp/ui/navigation/NavigationActions.kt
@@ -4,7 +4,6 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.AccountCircle
 import androidx.compose.material.icons.outlined.Place
 import androidx.compose.runtime.MutableState
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.navigation.NavHostController
 

--- a/app/src/main/java/com/android/streetworkapp/ui/navigation/TopAppBar.kt
+++ b/app/src/main/java/com/android/streetworkapp/ui/navigation/TopAppBar.kt
@@ -18,9 +18,7 @@ fun TopAppBarWrapper(navigationActions: NavigationActions, topAppBarManager: Top
     TopAppBar(
         modifier = Modifier.testTag("topAppBar"),
         title = {
-          Text(
-              modifier = Modifier.testTag("topAppBarTitle"),
-              text = it.getTopAppBarTitle())
+          Text(modifier = Modifier.testTag("topAppBarTitle"), text = it.getTopAppBarTitle())
         },
         colors =
             TopAppBarDefaults.topAppBarColors(containerColor = MaterialTheme.colorScheme.surface),

--- a/app/src/main/java/com/android/streetworkapp/ui/navigation/TopAppBar.kt
+++ b/app/src/main/java/com/android/streetworkapp/ui/navigation/TopAppBar.kt
@@ -20,16 +20,16 @@ fun TopAppBarWrapper(navigationActions: NavigationActions, topAppBarManager: Top
         title = {
           Text(
               modifier = Modifier.testTag("topAppBarTitle"),
-              text = topAppBarManager.getTopAppBarTitle())
+              text = it.getTopAppBarTitle())
         },
         colors =
             TopAppBarDefaults.topAppBarColors(containerColor = MaterialTheme.colorScheme.surface),
         navigationIcon = {
-          if (topAppBarManager.hasNavigationIcon()) {
+          if (it.hasNavigationIcon()) {
             IconButton(
                 onClick = { navigationActions.goBack() },
                 modifier = Modifier.testTag("goBackButton")) {
-                  Icon(topAppBarManager.getNavigationIcon(), contentDescription = "Back Icon")
+                  Icon(it.getNavigationIcon(), contentDescription = "Back Icon")
                 }
           }
         })

--- a/app/src/main/java/com/android/streetworkapp/ui/navigation/TopAppBar.kt
+++ b/app/src/main/java/com/android/streetworkapp/ui/navigation/TopAppBar.kt
@@ -1,7 +1,5 @@
 package com.android.streetworkapp.ui.navigation
 
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -16,25 +14,24 @@ import androidx.compose.ui.platform.testTag
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun TopAppBarWrapper(navigationActions: NavigationActions, topAppBarManager: TopAppBarManager?) {
-    topAppBarManager?.let {
-        TopAppBar(
-            modifier = Modifier.testTag("topAppBar"),
-            title = { Text(modifier = Modifier.testTag("topAppBarTitle"), text = topAppBarManager.getTopAppBarTitle()) },
-            colors =
-            TopAppBarDefaults.topAppBarColors(
-                containerColor = MaterialTheme.colorScheme.surface
-            ),
-            navigationIcon = {
-                if (topAppBarManager.hasNavigationIcon()) {
-                    IconButton(
-                        onClick = { navigationActions.goBack() },
-                        modifier = Modifier.testTag("goBackButton")
-                    ) {
-                        Icon(
-                            topAppBarManager.getNavigationIcon(), contentDescription = "Back Icon"
-                        )
-                    }
+  topAppBarManager?.let {
+    TopAppBar(
+        modifier = Modifier.testTag("topAppBar"),
+        title = {
+          Text(
+              modifier = Modifier.testTag("topAppBarTitle"),
+              text = topAppBarManager.getTopAppBarTitle())
+        },
+        colors =
+            TopAppBarDefaults.topAppBarColors(containerColor = MaterialTheme.colorScheme.surface),
+        navigationIcon = {
+          if (topAppBarManager.hasNavigationIcon()) {
+            IconButton(
+                onClick = { navigationActions.goBack() },
+                modifier = Modifier.testTag("goBackButton")) {
+                  Icon(topAppBarManager.getNavigationIcon(), contentDescription = "Back Icon")
                 }
-            })
-    }
+          }
+        })
+  }
 }

--- a/app/src/main/java/com/android/streetworkapp/ui/navigation/TopAppBar.kt
+++ b/app/src/main/java/com/android/streetworkapp/ui/navigation/TopAppBar.kt
@@ -18,8 +18,8 @@ import androidx.compose.ui.platform.testTag
 fun TopAppBarWrapper(navigationActions: NavigationActions, topAppBarManager: TopAppBarManager?) {
     topAppBarManager?.let {
         TopAppBar(
-            modifier = Modifier.testTag("TopAppBar"),
-            title = { Text(topAppBarManager.getTopAppBarTitle()) },
+            modifier = Modifier.testTag("topAppBar"),
+            title = { Text(modifier = Modifier.testTag("topAppBarTitle"), text = topAppBarManager.getTopAppBarTitle()) },
             colors =
             TopAppBarDefaults.topAppBarColors(
                 containerColor = MaterialTheme.colorScheme.surface

--- a/app/src/main/java/com/android/streetworkapp/ui/navigation/TopAppBar.kt
+++ b/app/src/main/java/com/android/streetworkapp/ui/navigation/TopAppBar.kt
@@ -1,0 +1,40 @@
+package com.android.streetworkapp.ui.navigation
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun TopAppBarWrapper(navigationActions: NavigationActions, topAppBarManager: TopAppBarManager?) {
+    topAppBarManager?.let {
+        TopAppBar(
+            modifier = Modifier.testTag("TopAppBar"),
+            title = { Text(topAppBarManager.getTopAppBarTitle()) },
+            colors =
+            TopAppBarDefaults.topAppBarColors(
+                containerColor = MaterialTheme.colorScheme.surface
+            ),
+            navigationIcon = {
+                if (topAppBarManager.hasNavigationIcon()) {
+                    IconButton(
+                        onClick = { navigationActions.goBack() },
+                        modifier = Modifier.testTag("goBackButton")
+                    ) {
+                        Icon(
+                            topAppBarManager.getNavigationIcon(), contentDescription = "Back Icon"
+                        )
+                    }
+                }
+            })
+    }
+}

--- a/app/src/main/java/com/android/streetworkapp/ui/navigation/TopAppBarManager.kt
+++ b/app/src/main/java/com/android/streetworkapp/ui/navigation/TopAppBarManager.kt
@@ -4,37 +4,32 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.ui.graphics.vector.ImageVector
 
-class TopAppBarManager(private var title: String = "", private var hasNavigationIcon: Boolean = false, private var navigationIcon: ImageVector? = null) {
+class TopAppBarManager(
+    private var title: String = "",
+    private var hasNavigationIcon: Boolean = false,
+    private var navigationIcon: ImageVector? = null
+) {
 
-    companion object {
-        val DEFAULT_TOP_APP_BAR_NAVIGATION_ICON = Icons.AutoMirrored.Filled.ArrowBack
-    }
-    /**
-     * Changes the TopAppBar title
-     */
-    fun setTopAppBarTitle(newTitle: String) {
-        this.title = newTitle
-    }
+  companion object {
+    val DEFAULT_TOP_APP_BAR_NAVIGATION_ICON = Icons.AutoMirrored.Filled.ArrowBack
+  }
+  /** Changes the TopAppBar title */
+  fun setTopAppBarTitle(newTitle: String) {
+    this.title = newTitle
+  }
 
-    /**
-     * Get the TopAppBar title
-     */
-    fun getTopAppBarTitle(): String {
-        return this.title
-    }
+  /** Get the TopAppBar title */
+  fun getTopAppBarTitle(): String {
+    return this.title
+  }
 
-    /**
-     * returns hasNavigationIcon
-     */
-    fun hasNavigationIcon(): Boolean {
-        return this.hasNavigationIcon
-    }
+  /** returns hasNavigationIcon */
+  fun hasNavigationIcon(): Boolean {
+    return this.hasNavigationIcon
+  }
 
-    /**
-     * Get the TopAppBar title
-     */
-    fun getNavigationIcon(): ImageVector {
-        return this.navigationIcon ?: TopAppBarManager.DEFAULT_TOP_APP_BAR_NAVIGATION_ICON
-    }
-
+  /** Get the TopAppBar title */
+  fun getNavigationIcon(): ImageVector {
+    return this.navigationIcon ?: TopAppBarManager.DEFAULT_TOP_APP_BAR_NAVIGATION_ICON
+  }
 }

--- a/app/src/main/java/com/android/streetworkapp/ui/navigation/TopAppBarManager.kt
+++ b/app/src/main/java/com/android/streetworkapp/ui/navigation/TopAppBarManager.kt
@@ -24,10 +24,10 @@ class TopAppBarManager(private var title: String = "", private var hasNavigation
     }
 
     /**
-     * Changes the TopAppBar navigationIcon
+     * returns hasNavigationIcon
      */
-    fun setNavigationIcon(newIcon: ImageVector) {
-        this.navigationIcon = newIcon
+    fun hasNavigationIcon(): Boolean {
+        return this.hasNavigationIcon
     }
 
     /**
@@ -37,10 +37,4 @@ class TopAppBarManager(private var title: String = "", private var hasNavigation
         return this.navigationIcon ?: TopAppBarManager.DEFAULT_TOP_APP_BAR_NAVIGATION_ICON
     }
 
-    /**
-     * returns hasNavigationIcon
-     */
-    fun hasNavigationIcon(): Boolean {
-        return this.hasNavigationIcon
-    }
 }

--- a/app/src/main/java/com/android/streetworkapp/ui/navigation/TopAppBarManager.kt
+++ b/app/src/main/java/com/android/streetworkapp/ui/navigation/TopAppBarManager.kt
@@ -1,0 +1,2 @@
+package com.android.streetworkapp.ui.navigation
+

--- a/app/src/main/java/com/android/streetworkapp/ui/navigation/TopAppBarManager.kt
+++ b/app/src/main/java/com/android/streetworkapp/ui/navigation/TopAppBarManager.kt
@@ -1,2 +1,46 @@
 package com.android.streetworkapp.ui.navigation
 
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.ui.graphics.vector.ImageVector
+
+class TopAppBarManager(private var title: String = "", private var hasNavigationIcon: Boolean = false, private var navigationIcon: ImageVector? = null) {
+
+    companion object {
+        val DEFAULT_TOP_APP_BAR_NAVIGATION_ICON = Icons.AutoMirrored.Filled.ArrowBack
+    }
+    /**
+     * Changes the TopAppBar title
+     */
+    fun setTopAppBarTitle(newTitle: String) {
+        this.title = newTitle
+    }
+
+    /**
+     * Get the TopAppBar title
+     */
+    fun getTopAppBarTitle(): String {
+        return this.title
+    }
+
+    /**
+     * Changes the TopAppBar navigationIcon
+     */
+    fun setNavigationIcon(newIcon: ImageVector) {
+        this.navigationIcon = newIcon
+    }
+
+    /**
+     * Get the TopAppBar title
+     */
+    fun getNavigationIcon(): ImageVector {
+        return this.navigationIcon ?: TopAppBarManager.DEFAULT_TOP_APP_BAR_NAVIGATION_ICON
+    }
+
+    /**
+     * returns hasNavigationIcon
+     */
+    fun hasNavigationIcon(): Boolean {
+        return this.hasNavigationIcon
+    }
+}

--- a/app/src/main/java/com/android/streetworkapp/ui/park/ParkOverview.kt
+++ b/app/src/main/java/com/android/streetworkapp/ui/park/ParkOverview.kt
@@ -17,23 +17,16 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.AccountCircle
 import androidx.compose.material.icons.filled.Star
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
-import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.ListItem
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
-import androidx.compose.material3.TopAppBar
-import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Alignment
@@ -56,7 +49,6 @@ import com.android.streetworkapp.model.park.Park
 import com.android.streetworkapp.ui.navigation.NavigationActions
 import com.android.streetworkapp.ui.navigation.Screen
 import com.android.streetworkapp.utils.toFormattedString
-
 
 /**
  * Display the overview of a park, including park details and a list of events.

--- a/app/src/main/java/com/android/streetworkapp/ui/park/ParkOverview.kt
+++ b/app/src/main/java/com/android/streetworkapp/ui/park/ParkOverview.kt
@@ -57,44 +57,6 @@ import com.android.streetworkapp.ui.navigation.NavigationActions
 import com.android.streetworkapp.ui.navigation.Screen
 import com.android.streetworkapp.utils.toFormattedString
 
-/**
- * Display the overview of a park, including park details and a list of events.
- *
- * @param navigationActions navigation class
- * @param park The park data to display.
- */
-@OptIn(ExperimentalMaterial3Api::class)
-@Composable
-fun ParkOverview(navigationActions: NavigationActions, park: Park, eventViewModel: EventViewModel) {
-  eventViewModel.getEvents()
-
-  Scaffold(
-      modifier = Modifier.testTag("ParkOverview"),
-      topBar = {
-        TopAppBar(
-            modifier = Modifier.testTag("ParkOverviewTopBar"),
-            title = {},
-            colors =
-                TopAppBarDefaults.topAppBarColors(
-                    containerColor = MaterialTheme.colorScheme.surface),
-            navigationIcon = {
-              IconButton(
-                  onClick = { navigationActions.goBack() },
-                  modifier = Modifier.testTag("goBackButtonOverviewScreen")) {
-                    Icon(
-                        Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Arrow Back Icon")
-                  }
-            })
-      }) { innerPadding ->
-        ParkOverviewScreen(
-            park,
-            innerPadding,
-            navigationActions,
-            eventViewModel) // we declare this so that it doesn't impact the tests in
-        // PackOverviewScreen (exceptions wouldn't be caught as it's async and
-        // tests would fail)
-      }
-}
 
 /**
  * Display the overview of a park, including park details and a list of events.

--- a/app/src/main/java/com/android/streetworkapp/ui/profile/AddFriend.kt
+++ b/app/src/main/java/com/android/streetworkapp/ui/profile/AddFriend.kt
@@ -10,16 +10,10 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.outlined.ArrowBack
 import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.OutlinedTextField
-import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
-import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -43,7 +37,6 @@ fun AddFriendScreen(
     navigationActions: NavigationActions,
     userViewModel: UserViewModel = viewModel(factory = UserViewModel.Factory),
     innerPaddingValues: PaddingValues = PaddingValues(0.dp)
-
 ) {
   // variable for outlined text
   var id by remember { mutableStateOf("") }
@@ -52,46 +45,44 @@ fun AddFriendScreen(
   // fake user ID (placeholder)
   val uid = "user123"
 
-  Box(
-      modifier = Modifier.testTag("addFriendScreen")
-  ){
-        Column(
-            modifier = Modifier.fillMaxSize().padding(innerPaddingValues).testTag("AddFriendColumn"),
-            horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.spacedBy(20.dp, Alignment.CenterVertically)) {
-              Image(
-                  painter = painterResource(id = R.drawable.place_holder),
-                  contentDescription = "profile picture",
-                  modifier = Modifier.size(200.dp))
+  Box(modifier = Modifier.testTag("addFriendScreen")) {
+    Column(
+        modifier = Modifier.fillMaxSize().padding(innerPaddingValues).testTag("AddFriendColumn"),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(20.dp, Alignment.CenterVertically)) {
+          Image(
+              painter = painterResource(id = R.drawable.place_holder),
+              contentDescription = "profile picture",
+              modifier = Modifier.size(200.dp))
 
-              // button to activate NFC (don't work)
-              NfcButton()
+          // button to activate NFC (don't work)
+          NfcButton()
 
-              // write friend ID
-              OutlinedTextField(
-                  value = id,
-                  onValueChange = { id = it },
-                  label = { Text("Friend ID") },
-                  placeholder = { Text("Add a friend with id") },
-                  modifier =
-                      Modifier.width(300.dp) // make the text field smaller
-                          .testTag("inputID"))
+          // write friend ID
+          OutlinedTextField(
+              value = id,
+              onValueChange = { id = it },
+              label = { Text("Friend ID") },
+              placeholder = { Text("Add a friend with id") },
+              modifier =
+                  Modifier.width(300.dp) // make the text field smaller
+                      .testTag("inputID"))
 
-              // Put the id inside the friend list of USER
-              Button(
-                  onClick = {
-                    if (id.isEmpty()) {
-                      // If id is null or empty, show a toast message to the user
-                      Toast.makeText(context, "ID cannot be empty.", Toast.LENGTH_SHORT).show()
-                    } else {
-                      // add the friend to the user firendlist
-                      userViewModel.addFriend(uid, id)
-                      Toast.makeText(context, "Friend request sent.", Toast.LENGTH_SHORT).show()
-                    }
-                  },
-                  modifier = Modifier.size(220.dp, 50.dp).testTag("RequestButton")) {
-                    Text(text = "Send request", fontSize = 17.sp)
-                  }
-            }
-      }
+          // Put the id inside the friend list of USER
+          Button(
+              onClick = {
+                if (id.isEmpty()) {
+                  // If id is null or empty, show a toast message to the user
+                  Toast.makeText(context, "ID cannot be empty.", Toast.LENGTH_SHORT).show()
+                } else {
+                  // add the friend to the user firendlist
+                  userViewModel.addFriend(uid, id)
+                  Toast.makeText(context, "Friend request sent.", Toast.LENGTH_SHORT).show()
+                }
+              },
+              modifier = Modifier.size(220.dp, 50.dp).testTag("RequestButton")) {
+                Text(text = "Send request", fontSize = 17.sp)
+              }
+        }
+  }
 }

--- a/app/src/main/java/com/android/streetworkapp/ui/profile/AddFriend.kt
+++ b/app/src/main/java/com/android/streetworkapp/ui/profile/AddFriend.kt
@@ -3,7 +3,9 @@ package com.android.streetworkapp.ui.profile
 import android.widget.Toast
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -39,7 +41,9 @@ import com.android.streetworkapp.ui.navigation.NavigationActions
 @Composable
 fun AddFriendScreen(
     navigationActions: NavigationActions,
-    userViewModel: UserViewModel = viewModel(factory = UserViewModel.Factory)
+    userViewModel: UserViewModel = viewModel(factory = UserViewModel.Factory),
+    innerPaddingValues: PaddingValues = PaddingValues(0.dp)
+
 ) {
   // variable for outlined text
   var id by remember { mutableStateOf("") }
@@ -48,24 +52,11 @@ fun AddFriendScreen(
   // fake user ID (placeholder)
   val uid = "user123"
 
-  Scaffold(
-      modifier = Modifier.testTag("addFriendScreen"),
-      topBar = {
-        // button to go back
-        TopAppBar(
-            title = { Text("Add a new friend", Modifier.testTag("addFriendTitle")) },
-            navigationIcon = {
-              IconButton(
-                  onClick = { navigationActions.goBack() }, Modifier.testTag("goBackButton")) {
-                    Icon(
-                        imageVector = Icons.AutoMirrored.Outlined.ArrowBack,
-                        contentDescription = "Back")
-                  }
-            })
-      },
-      content = { padding ->
+  Box(
+      modifier = Modifier.testTag("addFriendScreen")
+  ){
         Column(
-            modifier = Modifier.fillMaxSize().padding(padding).testTag("AddFriendColumn"),
+            modifier = Modifier.fillMaxSize().padding(innerPaddingValues).testTag("AddFriendColumn"),
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.spacedBy(20.dp, Alignment.CenterVertically)) {
               Image(
@@ -102,5 +93,5 @@ fun AddFriendScreen(
                     Text(text = "Send request", fontSize = 17.sp)
                   }
             }
-      })
+      }
 }

--- a/app/src/main/java/com/android/streetworkapp/ui/profile/Profile.kt
+++ b/app/src/main/java/com/android/streetworkapp/ui/profile/Profile.kt
@@ -12,7 +12,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
-import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -25,8 +24,6 @@ import androidx.compose.ui.unit.sp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.android.sample.R
 import com.android.streetworkapp.model.user.UserViewModel
-import com.android.streetworkapp.ui.navigation.BottomNavigationMenu
-import com.android.streetworkapp.ui.navigation.LIST_TOP_LEVEL_DESTINATION
 import com.android.streetworkapp.ui.navigation.NavigationActions
 import com.android.streetworkapp.ui.navigation.Screen
 
@@ -36,51 +33,47 @@ fun ProfileScreen(
     userViewModel: UserViewModel = viewModel(factory = UserViewModel.Factory),
     innerPaddingValues: PaddingValues = PaddingValues(0.dp)
 ) {
-  Box(
-      modifier = Modifier.testTag("ProfileScreen")
-  ) {
-        Column(
-            modifier = Modifier.fillMaxSize().padding(innerPaddingValues).testTag("ProfileColumn"),
-            horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.spacedBy(10.dp, Alignment.CenterVertically)) {
-              // profile placeholder
+  Box(modifier = Modifier.testTag("ProfileScreen")) {
+    Column(
+        modifier = Modifier.fillMaxSize().padding(innerPaddingValues).testTag("ProfileColumn"),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(10.dp, Alignment.CenterVertically)) {
+          // profile placeholder
 
-              Image(
-                  painter = painterResource(id = R.drawable.profile),
-                  contentDescription = "profile picture",
-                  modifier = Modifier.size(200.dp))
+          Image(
+              painter = painterResource(id = R.drawable.profile),
+              contentDescription = "profile picture",
+              modifier = Modifier.size(200.dp))
 
-              // score placeholder
+          // score placeholder
 
-              Text(
-                  text = "Score: 42’424",
-                  fontSize = 20.sp,
-                  modifier = Modifier.testTag("profileScore"))
+          Text(
+              text = "Score: 42’424", fontSize = 20.sp, modifier = Modifier.testTag("profileScore"))
 
-              // QR code placeholder
+          // QR code placeholder
 
-              Image(
-                  painter = painterResource(id = R.drawable.qrcode),
-                  contentDescription = "qr code",
-                  modifier = Modifier.size(260.dp))
+          Image(
+              painter = painterResource(id = R.drawable.qrcode),
+              contentDescription = "qr code",
+              modifier = Modifier.size(260.dp))
 
-              Spacer(modifier = Modifier.height(10.dp))
+          Spacer(modifier = Modifier.height(10.dp))
 
-              // button to go to add friend screen
-              Button(
-                  onClick = { navigationActions.navigateTo(Screen.ADD_FRIEND) },
-                  modifier = Modifier.size(220.dp, 50.dp).testTag("profileAddButton")) {
-                    Text(text = "Add a new friend", fontSize = 17.sp)
-                  }
+          // button to go to add friend screen
+          Button(
+              onClick = { navigationActions.navigateTo(Screen.ADD_FRIEND) },
+              modifier = Modifier.size(220.dp, 50.dp).testTag("profileAddButton")) {
+                Text(text = "Add a new friend", fontSize = 17.sp)
+              }
 
-              Spacer(modifier = Modifier.height(10.dp))
-              // button to train with a friend
-              Button(
-                  onClick = {},
-                  colors = ButtonDefaults.buttonColors(Color(0xFFA53A36)),
-                  modifier = Modifier.size(220.dp, 50.dp).testTag("profileTrainButton")) {
-                    Text(text = "Train with a friend", fontSize = 17.sp)
-                  }
-            }
-      }
+          Spacer(modifier = Modifier.height(10.dp))
+          // button to train with a friend
+          Button(
+              onClick = {},
+              colors = ButtonDefaults.buttonColors(Color(0xFFA53A36)),
+              modifier = Modifier.size(220.dp, 50.dp).testTag("profileTrainButton")) {
+                Text(text = "Train with a friend", fontSize = 17.sp)
+              }
+        }
+  }
 }

--- a/app/src/main/java/com/android/streetworkapp/ui/profile/Profile.kt
+++ b/app/src/main/java/com/android/streetworkapp/ui/profile/Profile.kt
@@ -2,7 +2,9 @@ package com.android.streetworkapp.ui.profile
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
@@ -31,18 +33,14 @@ import com.android.streetworkapp.ui.navigation.Screen
 @Composable
 fun ProfileScreen(
     navigationActions: NavigationActions,
-    userViewModel: UserViewModel = viewModel(factory = UserViewModel.Factory)
+    userViewModel: UserViewModel = viewModel(factory = UserViewModel.Factory),
+    innerPaddingValues: PaddingValues = PaddingValues(0.dp)
 ) {
-  Scaffold(
-      modifier = Modifier.testTag("ProfileScreen"),
-      bottomBar = {
-        BottomNavigationMenu(
-            onTabSelect = { route -> navigationActions.navigateTo(route) },
-            tabList = LIST_TOP_LEVEL_DESTINATION)
-      },
-      content = { padding ->
+  Box(
+      modifier = Modifier.testTag("ProfileScreen")
+  ) {
         Column(
-            modifier = Modifier.fillMaxSize().padding(padding).testTag("ProfileColumn"),
+            modifier = Modifier.fillMaxSize().padding(innerPaddingValues).testTag("ProfileColumn"),
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.spacedBy(10.dp, Alignment.CenterVertically)) {
               // profile placeholder
@@ -84,5 +82,5 @@ fun ProfileScreen(
                     Text(text = "Train with a friend", fontSize = 17.sp)
                   }
             }
-      })
+      }
 }


### PR DESCRIPTION
- **New Navigation classes and composable:**
  - Created  TopBarWrapper composable
  - Created ScreenParams and TopBarManager class that easily allows us to manage the screens bottom and top bar properties
  - Created a companion onject in ScreenParams that stores all the screen properties, this allows for topbar modification from any file/composable

- **MainActivity:**
  - Defined a single top level scaffold that shows the top/bottom bar depending on the current screen properties

- **Old Screens/Composables:**
  - Changed all the screens (except for EventOverview as it is too time consuming and should require a single issue for this task alone) to no longer have a scaffold
  - Adapted the existing tests of those composable to be compatible with the new structure

- **New Tests:**
  - Refactored the tests in BottomNavigationTest to test our new single top level scaffold structure
  - Implemented TopAppBarTest to test our new single top level scaffold new structure