### PR TITLE
Hotfix: Update the add event screen to have a park id in each event.

### DIFF
--- a/app/src/androidTest/java/com/android/streetworkapp/ui/parkoverview/AddEventTest.kt
+++ b/app/src/androidTest/java/com/android/streetworkapp/ui/parkoverview/AddEventTest.kt
@@ -133,7 +133,7 @@ class AddEventTest {
     composeTestRule.onNodeWithTag("addEventButton").performClick()
     composeTestRule
         .onNodeWithTag("addEventScreen")
-        .assertIsDisplayed() // we that that a click with no changes in the default value does not
+        .assertIsDisplayed() // we want that a click with no changes in the default value does not
     // make the user leave the screen
   }
 
@@ -154,7 +154,7 @@ class AddEventTest {
     composeTestRule.onNodeWithTag("addEventButton").performClick()
     composeTestRule
         .onNodeWithTag("addEventScreen")
-        .assertIsDisplayed() // we that that a click with changes in the time but no changes in the
+        .assertIsDisplayed() // we want that a click with changes in the time but no changes in the
     // default value of the title does not make the user leave the screen
   }
 }

--- a/app/src/androidTest/java/com/android/streetworkapp/ui/parkoverview/AddEventTest.kt
+++ b/app/src/androidTest/java/com/android/streetworkapp/ui/parkoverview/AddEventTest.kt
@@ -134,7 +134,7 @@ class AddEventTest {
     composeTestRule
         .onNodeWithTag("addEventScreen")
         .assertIsDisplayed() // we that that a click with no changes in the default value does not
-                             // make the user leave the screen
+    // make the user leave the screen
   }
 
   @Test
@@ -155,6 +155,6 @@ class AddEventTest {
     composeTestRule
         .onNodeWithTag("addEventScreen")
         .assertIsDisplayed() // we that that a click with changes in the time but no changes in the
-                             // default value of the title does not make the user leave the screen
+    // default value of the title does not make the user leave the screen
   }
 }

--- a/app/src/androidTest/java/com/android/streetworkapp/ui/parkoverview/AddEventTest.kt
+++ b/app/src/androidTest/java/com/android/streetworkapp/ui/parkoverview/AddEventTest.kt
@@ -121,4 +121,40 @@ class AddEventTest {
     composeTestRule.onNodeWithTag("addEventScreen").assertIsDisplayed()
     composeTestRule.onNodeWithTag("addEventButton").assertIsDisplayed()
   }
+
+  @Test
+  fun addEventScreenWithUnchangedTimeDoesNotChangeScreen() {
+    `when`(eventViewModel.getNewEid()).thenReturn("test")
+    composeTestRule.setContent {
+      AddEventScreen(navigationActions, parkViewModel, eventViewModel, userViewModel)
+    }
+
+    composeTestRule.onNodeWithTag("addEventScreen").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("addEventButton").performClick()
+    composeTestRule
+        .onNodeWithTag("addEventScreen")
+        .assertIsDisplayed() // we that that a click with no changes in the default value does not
+                             // make the user leave the screen
+  }
+
+  @Test
+  fun addEventScreenWithUnchangedTitleDoesNotChangeScreen() {
+    `when`(eventViewModel.getNewEid()).thenReturn("test")
+    composeTestRule.setContent {
+      AddEventScreen(navigationActions, parkViewModel, eventViewModel, userViewModel)
+    }
+
+    composeTestRule.onNodeWithTag("addEventScreen").assertIsDisplayed()
+
+    composeTestRule.onNodeWithTag("dateIcon").performClick()
+    composeTestRule.onNodeWithTag("validateDate").performClick()
+    composeTestRule.onNodeWithTag("timeIcon").performClick()
+    composeTestRule.onNodeWithTag("validateTime").performClick()
+
+    composeTestRule.onNodeWithTag("addEventButton").performClick()
+    composeTestRule
+        .onNodeWithTag("addEventScreen")
+        .assertIsDisplayed() // we that that a click with changes in the time but no changes in the
+                             // default value of the title does not make the user leave the screen
+  }
 }

--- a/app/src/main/java/com/android/streetworkapp/ui/event/AddEvent.kt
+++ b/app/src/main/java/com/android/streetworkapp/ui/event/AddEvent.kt
@@ -126,6 +126,9 @@ fun AddEventScreen(
                   .show()
             } else {
               eventViewModel.addEvent(event)
+              parkViewModel.currentPark.value?.let {
+                parkViewModel.addEventToPark(it.pid, event.eid)
+              }
               navigationActions.goBack()
             }
           },

--- a/app/src/main/java/com/android/streetworkapp/ui/event/AddEvent.kt
+++ b/app/src/main/java/com/android/streetworkapp/ui/event/AddEvent.kt
@@ -18,6 +18,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.DateRange
 import androidx.compose.material.icons.outlined.AccessTime
 import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonColors
 import androidx.compose.material3.DatePicker
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FloatingActionButton
@@ -163,7 +164,8 @@ fun EventTitleSelection(event: Event) {
         event.title = title
       },
       label = { Text("What kind of event do you want to create?") },
-      modifier = Modifier.testTag("titleTag").fillMaxWidth(0.9f).height(64.dp))
+      modifier = Modifier.testTag("titleTag").fillMaxWidth(0.9f).height(64.dp),
+  )
 }
 
 /**
@@ -218,7 +220,7 @@ fun ParticipantNumberSelection(event: Event) {
                 EventConstants.MIN_NUMBER_PARTICIPANTS.toFloat()..EventConstants
                         .MAX_NUMBER_PARTICIPANTS
                         .toFloat())
-        Text(text = sliderPosition.toInt().toString())
+        Text(text = sliderPosition.toInt().toString(), color = Color.Black)
       }
 }
 
@@ -285,6 +287,7 @@ fun TimeSelection(event: Event) {
 
         Button(
             modifier = Modifier.offset(x = 280.dp, y = 140.dp).testTag("validateDate"),
+            colors = ButtonColors(Color.Blue, Color.White, Color.Blue, Color.White),
             onClick = {
               showDatePicker = false
 
@@ -311,6 +314,7 @@ fun TimeSelection(event: Event) {
 
               Button(
                   modifier = Modifier.testTag("validateTime"),
+                  colors = ButtonColors(Color.Blue, Color.White, Color.Blue, Color.White),
                   onClick = {
                     showTimePicker = false
 

--- a/app/src/main/java/com/android/streetworkapp/ui/event/AddEvent.kt
+++ b/app/src/main/java/com/android/streetworkapp/ui/event/AddEvent.kt
@@ -40,6 +40,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
@@ -138,9 +139,10 @@ fun AddEventScreen(
                   .padding(40.dp)
                   .size(width = 150.dp, height = 40.dp)
                   .testTag("addEventButton"),
-      ) {
-        Text("Add new event")
-      }
+          containerColor = Color.Blue,
+          contentColor = Color.White) {
+            Text("Add new event")
+          }
     }
   }
 }

--- a/app/src/main/java/com/android/streetworkapp/ui/event/AddEvent.kt
+++ b/app/src/main/java/com/android/streetworkapp/ui/event/AddEvent.kt
@@ -120,17 +120,14 @@ fun AddEventScreen(
       FloatingActionButton(
           onClick = {
             if (event.date.toDate() < Calendar.getInstance().time) {
-              Toast.makeText(
-                      context, "Please select a valid time in the future", Toast.LENGTH_SHORT)
-                  .show()
+              Toast.makeText(context, "Date cannot be in the past", Toast.LENGTH_SHORT).show()
             } else if (event.title.isEmpty()) {
               Toast.makeText(context, "Please fill the title of the event", Toast.LENGTH_SHORT)
                   .show()
             } else {
               eventViewModel.addEvent(event)
-              parkViewModel.currentPark.value?.let {
-                parkViewModel.addEventToPark(it.pid, event.eid)
-              }
+              parkViewModel.addEventToPark(event.parkId, event.eid)
+
               navigationActions.goBack()
             }
           },

--- a/app/src/main/java/com/android/streetworkapp/ui/event/AddEvent.kt
+++ b/app/src/main/java/com/android/streetworkapp/ui/event/AddEvent.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -104,6 +105,7 @@ fun AddEventScreen(
           modifier = Modifier.fillMaxWidth(),
           verticalArrangement = Arrangement.spacedBy(18.dp),
           horizontalAlignment = Alignment.CenterHorizontally) {
+            Spacer(modifier = Modifier.size(24.dp))
             EventTitleSelection(event)
             EventDescriptionSelection(event)
             TimeSelection(event)
@@ -115,7 +117,11 @@ fun AddEventScreen(
           }
       FloatingActionButton(
           onClick = {
-            if (event.title.isEmpty()) {
+            if (event.date.toDate() < Calendar.getInstance().time) {
+              Toast.makeText(
+                      context, "Please select a valid time in the future", Toast.LENGTH_SHORT)
+                  .show()
+            } else if (event.title.isEmpty()) {
               Toast.makeText(context, "Please fill the title of the event", Toast.LENGTH_SHORT)
                   .show()
             } else {
@@ -124,7 +130,8 @@ fun AddEventScreen(
             }
           },
           modifier =
-              Modifier.align(Alignment.BottomCenter)
+              Modifier.align(Alignment.Center)
+                  .offset(0.dp, 100.dp)
                   .padding(40.dp)
                   .size(width = 150.dp, height = 40.dp)
                   .testTag("addEventButton"),

--- a/app/src/main/java/com/android/streetworkapp/ui/event/AddEvent.kt
+++ b/app/src/main/java/com/android/streetworkapp/ui/event/AddEvent.kt
@@ -91,7 +91,7 @@ fun AddEventScreen(
     event.owner = owner
   }
 
-  val parkId = "Unknown park" // TODO: do the same with ParkViewModel once updated
+  val parkId = parkViewModel.currentPark.value?.pid
   if (!parkId.isNullOrEmpty()) {
     event.parkId = parkId
   }


### PR DESCRIPTION
**Fixes in the AddEvent screen**
This pull request was created to update and fix the screen used to add a new event.

**Changes**
- Each new event has now a park id linked to it
- The user can not now chose a date in the past for an event (Note: a toDate() function was used, whose precision is not perfect. It does work to prevent the user from choosing a date that is yesterday or in 1970, but the user can still chose a time that is a few second before the current time. This could be improved but it already work as a sanity check)
- Update the UI of addEvent to be coherent with the changes made in the scaffold

