### PR TITLE
Feat/Fetching function in Park MVVM

### DIFF
--- a/app/src/main/java/com/android/streetworkapp/model/park/ParkRepository.kt
+++ b/app/src/main/java/com/android/streetworkapp/model/park/ParkRepository.kt
@@ -13,7 +13,7 @@ interface ParkRepository {
 
   suspend fun createPark(park: Park)
 
-  suspend fun getOrCreateParkByLocation(location: ParkLocation): Park
+  suspend fun getOrCreateParkByLocation(location: ParkLocation): Park?
 
   suspend fun updateName(pid: String, name: String)
 

--- a/app/src/main/java/com/android/streetworkapp/model/park/ParkRepository.kt
+++ b/app/src/main/java/com/android/streetworkapp/model/park/ParkRepository.kt
@@ -1,5 +1,7 @@
 package com.android.streetworkapp.model.park
 
+import com.android.streetworkapp.model.parklocation.ParkLocation
+
 /** A repository interface for park data. */
 interface ParkRepository {
 
@@ -10,6 +12,8 @@ interface ParkRepository {
   suspend fun getParkByLocationId(locationId: String): Park?
 
   suspend fun createPark(park: Park)
+
+  suspend fun getOrCreateParkByLocation(location: ParkLocation): Park
 
   suspend fun updateName(pid: String, name: String)
 

--- a/app/src/main/java/com/android/streetworkapp/model/park/ParkRepositoryFirestore.kt
+++ b/app/src/main/java/com/android/streetworkapp/model/park/ParkRepositoryFirestore.kt
@@ -77,6 +77,12 @@ class ParkRepositoryFirestore(private val db: FirebaseFirestore) : ParkRepositor
     }
   }
 
+  /**
+   * Get or create a park by its location.
+   *
+   * @param location The park location.
+   * @return The park with the given location, or a new park if it does not exist.
+   */
   override suspend fun getOrCreateParkByLocation(location: ParkLocation): Park? {
     require(location.id.isNotEmpty()) { "Location ID cannot be empty." }
     return try {

--- a/app/src/main/java/com/android/streetworkapp/model/park/ParkRepositoryFirestore.kt
+++ b/app/src/main/java/com/android/streetworkapp/model/park/ParkRepositoryFirestore.kt
@@ -15,6 +15,7 @@ class ParkRepositoryFirestore(private val db: FirebaseFirestore) : ParkRepositor
   }
 
   val PID_EMPTY = "Park ID cannot be empty."
+  val LID_EMPTY = "Location ID cannot be empty."
 
   /**
    * Get a new park ID.
@@ -49,7 +50,7 @@ class ParkRepositoryFirestore(private val db: FirebaseFirestore) : ParkRepositor
    * @return The park with the given location ID, or null if the park does not exist.
    */
   override suspend fun getParkByLocationId(locationId: String): Park? {
-    require(locationId.isNotEmpty()) { "Location ID cannot be empty." }
+    require(locationId.isNotEmpty()) { LID_EMPTY }
     return try {
       val document =
           db.collection(COLLECTION_PATH).whereEqualTo("location.id", locationId).get().await()
@@ -69,7 +70,7 @@ class ParkRepositoryFirestore(private val db: FirebaseFirestore) : ParkRepositor
    */
   override suspend fun createPark(park: Park) {
     require(park.pid.isNotEmpty()) { PID_EMPTY }
-    require(park.location.id.isNotEmpty()) { "Location ID cannot be empty." }
+    require(park.location.id.isNotEmpty()) { LID_EMPTY }
     try {
       db.collection(COLLECTION_PATH).document(park.pid).set(park).await()
     } catch (e: Exception) {
@@ -84,7 +85,7 @@ class ParkRepositoryFirestore(private val db: FirebaseFirestore) : ParkRepositor
    * @return The park with the given location, or a new park if it does not exist.
    */
   override suspend fun getOrCreateParkByLocation(location: ParkLocation): Park? {
-    require(location.id.isNotEmpty()) { "Location ID cannot be empty." }
+    require(location.id.isNotEmpty()) { LID_EMPTY }
     return try {
       val document =
           db.collection(COLLECTION_PATH).whereEqualTo("location.id", location.id).get().await()

--- a/app/src/main/java/com/android/streetworkapp/model/park/ParkUtils.kt
+++ b/app/src/main/java/com/android/streetworkapp/model/park/ParkUtils.kt
@@ -6,15 +6,13 @@ import com.android.streetworkapp.model.parklocation.ParkLocation
  * Create a new default park given the park ID and location
  *
  * @param pid The park ID.
- * @param lon The park longitude.
- * @param lat The park latitude.
- * @param locationId The park location ID.
+ * @param parkLocation The park location.
  */
-fun createDefaultPark(pid: String, lon: Double, lat: Double, locationId: String): Park {
+fun createDefaultPark(pid: String, parkLocation: ParkLocation): Park {
   return Park(
       pid = pid,
-      name = "Default Park $locationId",
-      location = ParkLocation(lon, lat, locationId),
+      name = "Default Park ${parkLocation.id}",
+      location = parkLocation,
       imageReference = "",
       rating = 1f,
       nbrRating = 0,

--- a/app/src/main/java/com/android/streetworkapp/model/park/ParkUtils.kt
+++ b/app/src/main/java/com/android/streetworkapp/model/park/ParkUtils.kt
@@ -1,0 +1,24 @@
+package com.android.streetworkapp.model.park
+
+import com.android.streetworkapp.model.parklocation.ParkLocation
+
+/**
+ * Create a new default park given the park ID and location
+ *
+ * @param pid The park ID.
+ * @param lon The park longitude.
+ * @param lat The park latitude.
+ * @param locationId The park location ID.
+ */
+fun createDefaultPark(pid: String, lon: Double, lat: Double, locationId: String): Park {
+  return Park(
+      pid = pid,
+      name = "Default Park $locationId",
+      location = ParkLocation(lon, lat, locationId),
+      imageReference = "",
+      rating = 1f,
+      nbrRating = 0,
+      capacity = 1,
+      occupancy = 0,
+      events = emptyList())
+}

--- a/app/src/main/java/com/android/streetworkapp/model/park/ParkViewModel.kt
+++ b/app/src/main/java/com/android/streetworkapp/model/park/ParkViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.android.streetworkapp.model.parklocation.ParkLocation
 import kotlinx.coroutines.launch
 
 open class ParkViewModel(private val repository: ParkRepository) : ViewModel() {
@@ -79,6 +80,18 @@ open class ParkViewModel(private val repository: ParkRepository) : ViewModel() {
    * @param park The park to create.
    */
   fun createPark(park: Park) = viewModelScope.launch { repository.createPark(park) }
+
+  /**
+   * Get or create a park by its location.
+   *
+   * @param location The park location.
+   */
+  fun getOrCreateParkByLocation(location: ParkLocation) {
+    viewModelScope.launch {
+      val park = repository.getOrCreateParkByLocation(location)
+      _park.value = park
+    }
+  }
 
   /**
    * Update the name of a park.

--- a/app/src/test/java/com/android/streetworkapp/model/park/ParkUtilsTest.kt
+++ b/app/src/test/java/com/android/streetworkapp/model/park/ParkUtilsTest.kt
@@ -1,0 +1,26 @@
+package com.android.streetworkapp.model.park
+
+import com.android.streetworkapp.model.parklocation.ParkLocation
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ParkUtilsTest {
+
+  @Test
+  fun testCreateDefaultPark() {
+    val pid = "123"
+    val parkLocation = ParkLocation(0.0, 0.0, "321")
+
+    val park = createDefaultPark(pid, parkLocation)
+
+    assertEquals(pid, park.pid)
+    assertEquals("Default Park ${parkLocation.id}", park.name)
+    assertEquals(parkLocation, park.location)
+    assertEquals("", park.imageReference)
+    assertEquals(1f, park.rating)
+    assertEquals(0, park.nbrRating)
+    assertEquals(1, park.capacity)
+    assertEquals(0, park.occupancy)
+    assertEquals(emptyList<String>(), park.events)
+  }
+}

--- a/app/src/test/java/com/android/streetworkapp/model/park/ParkViewModelTest.kt
+++ b/app/src/test/java/com/android/streetworkapp/model/park/ParkViewModelTest.kt
@@ -212,4 +212,17 @@ class ParkViewModelTest {
     verify(repository).getParkByPid(pid)
     assertEquals(park, observedPark)
   }
+
+  @Test
+  fun getOrCreateParkByLocationCallsRepositoryWithCorrectLocationAndReturnsPark() = runTest {
+    val parkLocation = ParkLocation(0.0, 0.0, "location123")
+    val park = createPark(pid = "123", locationId = "location123")
+    whenever(repository.getOrCreateParkByLocation(parkLocation)).thenReturn(park)
+
+    val result = parkViewModel.getOrCreateParkByLocation(parkLocation)
+    testDispatcher.scheduler.advanceUntilIdle()
+
+    verify(repository).getOrCreateParkByLocation(parkLocation)
+    assertEquals(park, result)
+  }
 }

--- a/app/src/test/java/com/android/streetworkapp/model/park/ParkViewModelTest.kt
+++ b/app/src/test/java/com/android/streetworkapp/model/park/ParkViewModelTest.kt
@@ -218,11 +218,8 @@ class ParkViewModelTest {
     val parkLocation = ParkLocation(0.0, 0.0, "location123")
     val park = createPark(pid = "123", locationId = "location123")
     whenever(repository.getOrCreateParkByLocation(parkLocation)).thenReturn(park)
-
-    val result = parkViewModel.getOrCreateParkByLocation(parkLocation)
+    parkViewModel.getOrCreateParkByLocation(parkLocation)
     testDispatcher.scheduler.advanceUntilIdle()
-
     verify(repository).getOrCreateParkByLocation(parkLocation)
-    assertEquals(park, result)
   }
 }


### PR DESCRIPTION
### Summary

This pull request adds a new function to the Park MVVM that fetches a park by location ID if it exists or creates a new park if it does not. This enhancement streamlines the process of managing parks based on their location IDs.

### Changes

- Added the function to the `ParkRepository` interface.
- Implemented the function in the `ParkRepositoryFirestore` class.
- Implemented the function in the `ParkViewModel` class.

### Testing 

- Added new tests to `ParkRepositoryFirestore` to test the function
- Added new tests to `ParkViewModel` to test the function
- Implemented `ParkUtils` tests to test the creation of a default park