### PR TITLE
Hotfix/park mvvm 

### DIFF
--- a/app/src/main/java/com/android/streetworkapp/model/park/ParkViewModel.kt
+++ b/app/src/main/java/com/android/streetworkapp/model/park/ParkViewModel.kt
@@ -1,21 +1,21 @@
 package com.android.streetworkapp.model.park
 
-import androidx.lifecycle.LiveData
-import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.android.streetworkapp.model.parklocation.ParkLocation
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 
 open class ParkViewModel(private val repository: ParkRepository) : ViewModel() {
 
   // LiveData of the current park
-  private val _currentPark = MutableLiveData<Park?>()
-  val currentPark: LiveData<Park?>
+  private val _currentPark = MutableStateFlow<Park?>(null)
+  val currentPark: StateFlow<Park?>
     get() = _currentPark
 
-  private val _park = MutableLiveData<Park?>()
-  val park: LiveData<Park?>
+  private val _park = MutableStateFlow<Park?>(null)
+  val park: StateFlow<Park?>
     get() = _park
 
   /**
@@ -35,7 +35,7 @@ open class ParkViewModel(private val repository: ParkRepository) : ViewModel() {
   fun loadCurrentPark(pid: String) {
     viewModelScope.launch {
       val fetchedPark = repository.getParkByPid(pid)
-      _currentPark.setValue(fetchedPark)
+      _currentPark.value = fetchedPark
     }
   }
 
@@ -57,7 +57,7 @@ open class ParkViewModel(private val repository: ParkRepository) : ViewModel() {
   fun getParkByPid(pid: String) {
     viewModelScope.launch {
       val fetchedPark = repository.getParkByPid(pid)
-      _park.setValue(fetchedPark)
+      _park.value = fetchedPark
     }
   }
 
@@ -70,7 +70,7 @@ open class ParkViewModel(private val repository: ParkRepository) : ViewModel() {
   fun getParkByLocationId(locationId: String) {
     viewModelScope.launch {
       val fetchedPark = repository.getParkByLocationId(locationId)
-      _park.setValue(fetchedPark)
+      _park.value = fetchedPark
     }
   }
 

--- a/app/src/main/java/com/android/streetworkapp/model/park/ParkViewModel.kt
+++ b/app/src/main/java/com/android/streetworkapp/model/park/ParkViewModel.kt
@@ -9,7 +9,7 @@ import kotlinx.coroutines.launch
 
 open class ParkViewModel(private val repository: ParkRepository) : ViewModel() {
 
-  // LiveData of the current park
+  // StateFlow of the current park
   private val _currentPark = MutableStateFlow<Park?>(null)
   val currentPark: StateFlow<Park?>
     get() = _currentPark

--- a/app/src/test/java/com/android/streetworkapp/model/park/ParkViewModelTest.kt
+++ b/app/src/test/java/com/android/streetworkapp/model/park/ParkViewModelTest.kt
@@ -4,6 +4,7 @@ import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import com.android.streetworkapp.model.parklocation.ParkLocation
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
@@ -175,13 +176,11 @@ class ParkViewModelTest {
   }
 
   @Test
-  fun setCurrentParkUpdatesCurrentPark() {
+  fun setCurrentParkUpdatesCurrentPark() = runTest {
     val park = createPark()
     parkViewModel.setCurrentPark(park)
 
-    var observedPark: Park? = null
-    parkViewModel.currentPark.observeForever { observedPark = it }
-
+    val observedPark = parkViewModel.currentPark.first()
     assertEquals(park, observedPark)
   }
 
@@ -193,9 +192,7 @@ class ParkViewModelTest {
     parkViewModel.getParkByPid("123")
     testDispatcher.scheduler.advanceUntilIdle()
 
-    var observedPark: Park? = null
-    parkViewModel.park.observeForever { observedPark = it }
-
+    val observedPark = parkViewModel.park.first()
     verify(repository).getParkByPid("123")
     assertEquals(park, observedPark)
   }
@@ -207,8 +204,8 @@ class ParkViewModelTest {
     whenever(repository.getParkByPid(pid)).thenReturn(park)
     parkViewModel.loadCurrentPark(pid)
     testDispatcher.scheduler.advanceUntilIdle()
-    var observedPark: Park? = null
-    parkViewModel.currentPark.observeForever { observedPark = it }
+
+    val observedPark = parkViewModel.currentPark.first()
     verify(repository).getParkByPid(pid)
     assertEquals(park, observedPark)
   }


### PR DESCRIPTION
Since `MutableLiveData` don't work in our MVVMs, we need to replace them with `MutableStateFlow`. The purpose of this branch is to remove bottlenecks and quickly complete the epic for parks.

This branch is necessary so that I can test the changes I need to make in mvvm park. (the [other branch](https://github.com/SwEnt-Group8/Street-work-app/issues/82) adds the possibility for users to rate parks)
