### PR TITLE
Hotfix/handle query took too long from Nominatim

### DIFF
--- a/app/src/main/java/com/android/streetworkapp/model/park/NominatimParkNameRepository.kt
+++ b/app/src/main/java/com/android/streetworkapp/model/park/NominatimParkNameRepository.kt
@@ -45,17 +45,21 @@ class NominatimParkNameRepository(val client: OkHttpClient) : ParkNameRepository
               }
 
               override fun onResponse(call: Call, response: Response) {
-                onSuccess(decodeRoadJson(response.body!!.string()))
+                onSuccess(decodeRoadJson(response.body!!.string(), locationId))
               }
             })
   }
 
-  fun decodeRoadJson(json: String): String {
+  fun decodeRoadJson(json: String, locationId: String): String {
     require(json.isNotEmpty())
-    val jsonArray = JSONArray(json)
-    val jsonObject = jsonArray.getJSONObject(0)
-    val address = jsonObject.getJSONObject("address")
-    val road = address.getString("road")
-    return road
+    try {
+      val jsonArray = JSONArray(json)
+      val jsonObject = jsonArray.getJSONObject(0)
+      val address = jsonObject.getJSONObject("address")
+      val road = address.getString("road")
+      return road
+    } catch (_: Exception) {
+      return "Default Park: $locationId"
+    }
   }
 }

--- a/app/src/main/java/com/android/streetworkapp/model/park/NominatimParkNameRepository.kt
+++ b/app/src/main/java/com/android/streetworkapp/model/park/NominatimParkNameRepository.kt
@@ -59,7 +59,7 @@ class NominatimParkNameRepository(val client: OkHttpClient) : ParkNameRepository
       val road = address.getString("road")
       return road
     } catch (_: Exception) {
-      return "Default Park: $locationId"
+      return "Default Park $locationId"
     }
   }
 }

--- a/app/src/test/java/com/android/streetworkapp/model/park/NominatimParkNameRepositoryTest.kt
+++ b/app/src/test/java/com/android/streetworkapp/model/park/NominatimParkNameRepositoryTest.kt
@@ -71,7 +71,7 @@ class NominatimParkNameRepositoryTest {
     val string = "Query took took long"
 
     val name = NominatimParkNameRepository(okHttpClient).decodeRoadJson(string, "test")
-    assert(name == "Default Park: test")
+    assert(name == "Default Park test")
   }
 
   @Test

--- a/app/src/test/java/com/android/streetworkapp/model/park/NominatimParkNameRepositoryTest.kt
+++ b/app/src/test/java/com/android/streetworkapp/model/park/NominatimParkNameRepositoryTest.kt
@@ -62,8 +62,17 @@ class NominatimParkNameRepositoryTest {
             "    ]\n" +
             "  }\n" +
             "]"
-    val name = NominatimParkNameRepository(okHttpClient).decodeRoadJson(string)
+    val name = NominatimParkNameRepository(okHttpClient).decodeRoadJson(string,"test")
     assert(name == "Avenue des Désertes")
+  }
+
+
+  @Test
+  fun decodeJSONRoadWorksNominatimTookTooLongString() {
+    val string = "Query took took long"
+
+    val name = NominatimParkNameRepository(okHttpClient).decodeRoadJson(string,"test")
+    assert(name == "Default Park: test")
   }
 
   @Test

--- a/app/src/test/java/com/android/streetworkapp/model/park/NominatimParkNameRepositoryTest.kt
+++ b/app/src/test/java/com/android/streetworkapp/model/park/NominatimParkNameRepositoryTest.kt
@@ -62,16 +62,15 @@ class NominatimParkNameRepositoryTest {
             "    ]\n" +
             "  }\n" +
             "]"
-    val name = NominatimParkNameRepository(okHttpClient).decodeRoadJson(string,"test")
+    val name = NominatimParkNameRepository(okHttpClient).decodeRoadJson(string, "test")
     assert(name == "Avenue des Désertes")
   }
-
 
   @Test
   fun decodeJSONRoadWorksNominatimTookTooLongString() {
     val string = "Query took took long"
 
-    val name = NominatimParkNameRepository(okHttpClient).decodeRoadJson(string,"test")
+    val name = NominatimParkNameRepository(okHttpClient).decodeRoadJson(string, "test")
     assert(name == "Default Park: test")
   }
 


### PR DESCRIPTION
**Fix: Query took too long from Nominatim**
This Pull Request is used to handle the current response of Nominatim to every query, which is : "Query took too long to process." This response is a string that has not the JSON format, which makes our app crash. A try-catch is added to handle this situation

(We imagine that the API is currently down for every user, and that is why we have this response after we tried on different devices)

**How to test**
You can change the collection path of the parks to have a new fresh database, and check that the app do not crash on never seen before parks. (They also should have the default name, since Nominatim can not at the moment give the right name)