### PR TITLE
Feat/display user on the map

### DIFF
--- a/app/src/androidTest/java/com/android/streetworkapp/end2end/End2EndGeneral.kt
+++ b/app/src/androidTest/java/com/android/streetworkapp/end2end/End2EndGeneral.kt
@@ -7,6 +7,7 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
+import androidx.test.rule.GrantPermissionRule
 import com.android.streetworkapp.StreetWorkApp
 import com.android.streetworkapp.model.event.EventRepository
 import com.android.streetworkapp.model.event.EventViewModel
@@ -40,6 +41,11 @@ class End2EndGeneral {
   @InjectMocks private lateinit var progressionViewModel: ProgressionViewModel
 
   @get:Rule val composeTestRule = createComposeRule()
+
+  // grant the permission to access location (remove the window for permission)
+  @get:Rule
+  val permissionRule: GrantPermissionRule =
+      GrantPermissionRule.grant(android.Manifest.permission.ACCESS_FINE_LOCATION)
 
   private val mockedUserUid = "123456"
 


### PR DESCRIPTION
**This pull request is to correct the CI error on https://github.com/SwEnt-Group8/Street-work-app/pull/110**


### Display the user on the map using google API

![image](https://github.com/user-attachments/assets/2b2202f9-acff-42ec-a146-719ea22a8fe3)


## Changes

- Changed `Map.kt`, now it will ask for permission when the app is booted and if permssion is acquired it will update the location to where the user is.
- Changed `MapUi.kt` to display the user as a blue dot on the map
- Added 2 new classes in utils : `LocationService.kt` and `PermissionManager` abstraction of function used in `Map.kt`
_`LocationService.kt` : if permission is granted, it update the user location_
_`PermissionManage` : manage the permission, can verify permission and ask for it_

    Changed the image in Profile.kt to display the current user profile picture
    Added a dependecies in build.gradle.kts for coil (needed to display the profile picture)

## Testing

- Granted location permission inside `MapUiTest.kt`, it would crashes otherwise
- Added test for mapManager function of `Map.kt` (the coverage is only at 78%)



