### PR TITLE
Refactor/Update and finish the rework of the progression MVVM 

### DIFF
--- a/app/src/main/java/com/android/streetworkapp/model/progression/Progression.kt
+++ b/app/src/main/java/com/android/streetworkapp/model/progression/Progression.kt
@@ -41,7 +41,7 @@ enum class Ranks(val score: Int) {
   SILVER(1000),
   GOLD(10000),
   PLATINUM(100000),
-  CEILING(1000000)
+  CEILING(100000)
 }
 
 enum class MedalsAchievement(val achievement: Achievement) {

--- a/app/src/main/java/com/android/streetworkapp/model/progression/Progression.kt
+++ b/app/src/main/java/com/android/streetworkapp/model/progression/Progression.kt
@@ -40,7 +40,8 @@ enum class Ranks(val score: Int) {
   BRONZE(100),
   SILVER(1000),
   GOLD(10000),
-  PLATINUM(100000)
+  PLATINUM(100000),
+  CEILING(1000000)
 }
 
 enum class MedalsAchievement(val achievement: Achievement) {
@@ -68,7 +69,7 @@ enum class MedalsAchievement(val achievement: Achievement) {
           "Last medal"))
 }
 
-enum class SCORE_INCREASE(val scoreAdded: Int) {
+enum class ScoreIncrease(val scoreAdded: Int) {
   CREATE_EVENT(10),
   JOIN_EVENT(5),
   ADD_FRIEND(10)

--- a/app/src/main/java/com/android/streetworkapp/model/progression/ProgressionRepository.kt
+++ b/app/src/main/java/com/android/streetworkapp/model/progression/ProgressionRepository.kt
@@ -5,8 +5,6 @@ interface ProgressionRepository {
 
   fun getNewProgressionId(): String
 
-  fun getProgression(uid: String, onSuccess: (Progression) -> Unit, onFailure: (Exception) -> Unit)
-
   suspend fun getOrAddProgression(uid: String): Progression
 
   suspend fun updateProgressionWithAchievementAndGoal(
@@ -14,6 +12,4 @@ interface ProgressionRepository {
       achievements: List<String>,
       goal: Int
   )
-
-  suspend fun createProgression(uid: String, progressionId: String)
 }

--- a/app/src/main/java/com/android/streetworkapp/model/progression/ProgressionRepositoryFirestore.kt
+++ b/app/src/main/java/com/android/streetworkapp/model/progression/ProgressionRepositoryFirestore.kt
@@ -29,8 +29,7 @@ class ProgressionRepositoryFirestore(private val db: FirebaseFirestore) : Progre
       if (document.isEmpty) {
         val progressionId = this.getNewProgressionId()
         val progression = Progression(progressionId, uid, Ranks.BRONZE.score)
-        db.collection(COLLECTION_PATH).document().set(progression).await()
-
+        db.collection(COLLECTION_PATH).document(progressionId).set(progression).await()
         progression
       } else {
         documentToProgression(document.documents[0])

--- a/app/src/main/java/com/android/streetworkapp/model/progression/ProgressionViewModel.kt
+++ b/app/src/main/java/com/android/streetworkapp/model/progression/ProgressionViewModel.kt
@@ -43,7 +43,7 @@ open class ProgressionViewModel(private val repository: ProgressionRepository) :
    */
   fun checkScore(score: Int) =
       viewModelScope.launch {
-        while (_currentProgression.value.currentGoal < score && score <= Ranks.PLATINUM.score) {
+        while (_currentProgression.value.currentGoal < score && score <= Ranks.CEILING.score) {
           val unlockedAchievement = getMedalByScore(_currentProgression.value.currentGoal)
           val nextMedalName =
               enumValues<MedalsAchievement>().getOrNull(unlockedAchievement.ordinal + 1)?.name

--- a/app/src/main/java/com/android/streetworkapp/model/progression/ProgressionViewModel.kt
+++ b/app/src/main/java/com/android/streetworkapp/model/progression/ProgressionViewModel.kt
@@ -43,7 +43,7 @@ open class ProgressionViewModel(private val repository: ProgressionRepository) :
    */
   fun checkScore(score: Int) =
       viewModelScope.launch {
-        if (_currentProgression.value.currentGoal < score) {
+        while (_currentProgression.value.currentGoal < score && score <= Ranks.PLATINUM.score) {
           val unlockedAchievement = getMedalByScore(_currentProgression.value.currentGoal)
           val nextMedalName =
               enumValues<MedalsAchievement>().getOrNull(unlockedAchievement.ordinal + 1)?.name
@@ -51,7 +51,7 @@ open class ProgressionViewModel(private val repository: ProgressionRepository) :
               ?.let { // if this executes this means that the user is not at the highest rank
                 val newAchievements =
                     _currentProgression.value.achievements + unlockedAchievement.name
-                currentProgression.value.currentGoal = enumValueOf<Ranks>(it).score
+                _currentProgression.value.currentGoal = enumValueOf<Ranks>(it).score
 
                 repository.updateProgressionWithAchievementAndGoal(
                     _currentProgression.value.progressionId,

--- a/app/src/main/java/com/android/streetworkapp/model/progression/ProgressionViewModel.kt
+++ b/app/src/main/java/com/android/streetworkapp/model/progression/ProgressionViewModel.kt
@@ -1,6 +1,5 @@
 package com.android.streetworkapp.model.progression
 
-import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.android.streetworkapp.model.progression.MedalsAchievement.BRONZE
@@ -17,10 +16,6 @@ open class ProgressionViewModel(private val repository: ProgressionRepository) :
 
   private val _currentProgression = MutableStateFlow<Progression>(Progression())
   val currentProgression: StateFlow<Progression> = _currentProgression.asStateFlow()
-
-  companion object {
-    private const val ERROR_UID_EMPTY = "The uid must not be empty."
-  }
 
   /**
    * Used to have a unique progressionId in the database.
@@ -39,29 +34,6 @@ open class ProgressionViewModel(private val repository: ProgressionRepository) :
   fun getOrAddProgression(uid: String) {
     viewModelScope.launch { _currentProgression.value = repository.getOrAddProgression(uid) }
   }
-
-  /**
-   * Fetch the progression linked to the given uid
-   *
-   * @param uid: The uid (User Id)
-   */
-  fun getCurrentProgression(uid: String) {
-    require(uid.isNotEmpty()) { ERROR_UID_EMPTY }
-
-    repository.getProgression(
-        uid = uid,
-        onSuccess = { progression -> _currentProgression.value = progression },
-        onFailure = { Log.e("FirestoreError", "Error getting events: ${it.message}") })
-  }
-
-  /**
-   * Create the progression linked to the given uid
-   *
-   * @param uid: The uid (User Id)
-   * @param progressionId: The id of the "progression" object
-   */
-  fun createProgression(uid: String, progressionId: String) =
-      viewModelScope.launch { repository.createProgression(uid, progressionId) }
 
   /**
    * Check the score of the user. With enough points, the user wins medals. This function should be

--- a/app/src/main/java/com/android/streetworkapp/ui/event/AddEvent.kt
+++ b/app/src/main/java/com/android/streetworkapp/ui/event/AddEvent.kt
@@ -52,6 +52,7 @@ import com.android.streetworkapp.model.event.Event
 import com.android.streetworkapp.model.event.EventConstants
 import com.android.streetworkapp.model.event.EventViewModel
 import com.android.streetworkapp.model.park.ParkViewModel
+import com.android.streetworkapp.model.progression.SCORE_INCREASE
 import com.android.streetworkapp.model.user.UserViewModel
 import com.android.streetworkapp.ui.navigation.NavigationActions
 import com.android.streetworkapp.ui.theme.ColorPalette
@@ -131,7 +132,7 @@ fun AddEventScreen(
               parkViewModel.addEventToPark(event.parkId, event.eid)
 
               // Used for the gamification feature
-              userViewModel.increaseUserScore(event.owner, 510)
+              userViewModel.increaseUserScore(event.owner, SCORE_INCREASE.CREATE_EVENT.scoreAdded)
               // Note: temporary value to use the progression screen. Should be update once
               // the gamification is completed
               Toast.makeText(context, "+510 Points", Toast.LENGTH_SHORT).show()

--- a/app/src/main/java/com/android/streetworkapp/ui/event/AddEvent.kt
+++ b/app/src/main/java/com/android/streetworkapp/ui/event/AddEvent.kt
@@ -135,7 +135,7 @@ fun AddEventScreen(
               userViewModel.increaseUserScore(event.owner, SCORE_INCREASE.CREATE_EVENT.scoreAdded)
               // Note: temporary value to use the progression screen. Should be update once
               // the gamification is completed
-              Toast.makeText(context, "+510 Points", Toast.LENGTH_SHORT).show()
+              Toast.makeText(context, "+"+SCORE_INCREASE.CREATE_EVENT.scoreAdded+" Points", Toast.LENGTH_SHORT).show()
 
               navigationActions.goBack()
             }

--- a/app/src/main/java/com/android/streetworkapp/ui/event/AddEvent.kt
+++ b/app/src/main/java/com/android/streetworkapp/ui/event/AddEvent.kt
@@ -52,7 +52,7 @@ import com.android.streetworkapp.model.event.Event
 import com.android.streetworkapp.model.event.EventConstants
 import com.android.streetworkapp.model.event.EventViewModel
 import com.android.streetworkapp.model.park.ParkViewModel
-import com.android.streetworkapp.model.progression.SCORE_INCREASE
+import com.android.streetworkapp.model.progression.ScoreIncrease
 import com.android.streetworkapp.model.user.UserViewModel
 import com.android.streetworkapp.ui.navigation.NavigationActions
 import com.android.streetworkapp.ui.theme.ColorPalette
@@ -132,12 +132,12 @@ fun AddEventScreen(
               parkViewModel.addEventToPark(event.parkId, event.eid)
 
               // Used for the gamification feature
-              userViewModel.increaseUserScore(event.owner, SCORE_INCREASE.CREATE_EVENT.scoreAdded)
+              userViewModel.increaseUserScore(event.owner, ScoreIncrease.CREATE_EVENT.scoreAdded)
               // Note: temporary value to use the progression screen. Should be update once
               // the gamification is completed
               Toast.makeText(
                       context,
-                      "+" + SCORE_INCREASE.CREATE_EVENT.scoreAdded + " Points",
+                      "+" + ScoreIncrease.CREATE_EVENT.scoreAdded + " Points",
                       Toast.LENGTH_SHORT)
                   .show()
 

--- a/app/src/main/java/com/android/streetworkapp/ui/event/AddEvent.kt
+++ b/app/src/main/java/com/android/streetworkapp/ui/event/AddEvent.kt
@@ -135,7 +135,11 @@ fun AddEventScreen(
               userViewModel.increaseUserScore(event.owner, SCORE_INCREASE.CREATE_EVENT.scoreAdded)
               // Note: temporary value to use the progression screen. Should be update once
               // the gamification is completed
-              Toast.makeText(context, "+"+SCORE_INCREASE.CREATE_EVENT.scoreAdded+" Points", Toast.LENGTH_SHORT).show()
+              Toast.makeText(
+                      context,
+                      "+" + SCORE_INCREASE.CREATE_EVENT.scoreAdded + " Points",
+                      Toast.LENGTH_SHORT)
+                  .show()
 
               navigationActions.goBack()
             }

--- a/app/src/main/java/com/android/streetworkapp/ui/event/AddEvent.kt
+++ b/app/src/main/java/com/android/streetworkapp/ui/event/AddEvent.kt
@@ -130,6 +130,12 @@ fun AddEventScreen(
               eventViewModel.addEvent(event)
               parkViewModel.addEventToPark(event.parkId, event.eid)
 
+              // Used for the gamification feature
+              userViewModel.increaseUserScore(event.owner, 510)
+              // Note: temporary value to use the progression screen. Should be update once
+              // the gamification is completed
+              Toast.makeText(context, "+510 Points", Toast.LENGTH_SHORT).show()
+
               navigationActions.goBack()
             }
           },

--- a/app/src/main/java/com/android/streetworkapp/ui/progress/Progression.kt
+++ b/app/src/main/java/com/android/streetworkapp/ui/progress/Progression.kt
@@ -75,6 +75,7 @@ fun ProgressScreen(
   val currentProgression by progressionViewModel.currentProgression.collectAsState()
 
   currentUser?.uid?.let { progressionViewModel.getOrAddProgression(it) }
+  currentUser?.let { progressionViewModel.checkScore(it.score) }
 
   val progressionPercentage = // in case of error set it to 0, otherwise score/currentGoal
       (if (currentUser == null || currentProgression.currentGoal == 0) 0f

--- a/app/src/test/java/com/android/streetworkapp/model/progression/ProgressionRepositoryFirestoreTest.kt
+++ b/app/src/test/java/com/android/streetworkapp/model/progression/ProgressionRepositoryFirestoreTest.kt
@@ -15,7 +15,6 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mock
-import org.mockito.Mockito.timeout
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.`when`
 import org.mockito.MockitoAnnotations
@@ -68,52 +67,6 @@ class ProgressionRepositoryFirestoreTest {
 
     val progressionId = progressionRepository.getNewProgressionId()
     assertEquals("uniqueProgressionId", progressionId)
-  }
-
-  @Test
-  fun addEventAddsEventSuccessfully() = runTest {
-    `when`(collection.document("test")).thenReturn(documentRef)
-    `when`(documentRef.set("test")).thenReturn(Tasks.forResult(null))
-
-    progressionRepository.createProgression("test", "test")
-    verify(documentRef).set(Progression("test", "test", Ranks.BRONZE.score))
-  }
-
-  @Test
-  fun getProgressionWithCallbackTest() = runTest {
-    `when`(collection.whereEqualTo("uid", "test")).thenReturn(collection)
-
-    `when`(db.collection("progressions")).thenReturn(collection)
-    `when`(collection.document("test")).thenReturn(documentRef)
-
-    val taskCompletionSource = TaskCompletionSource<DocumentSnapshot>()
-    taskCompletionSource.setResult(document)
-    val task = taskCompletionSource.task
-    `when`(documentRef.get()).thenReturn(task)
-
-    var progression = Progression()
-    progressionRepository.getProgression("test", { p -> progression = p }, {})
-
-    verify(collection).whereEqualTo("uid", "test")
-  }
-
-  @Test
-  fun getProgressionTest() = runTest {
-
-    // Ensure that mockToDoQuerySnapshot is properly initialized and mocked
-    `when`(collection.get()).thenReturn(Tasks.forResult(query))
-    `when`(collection.whereEqualTo("uid", "test")).thenReturn(collection)
-
-    // Ensure the QuerySnapshot returns a list of mock DocumentSnapshots
-    `when`(query.documents).thenReturn(listOf())
-
-    val onSuccess: (Progression) -> Unit = {}
-    val onFailure: (Exception) -> Unit = {}
-    progressionRepository.getProgression("test", onSuccess, onFailure)
-
-    // Verify that the 'documents' field was accessed
-    org.mockito.kotlin.verify(timeout(100)) { (query).documents }
-    verify(collection).get()
   }
 
   @Test

--- a/app/src/test/java/com/android/streetworkapp/model/progression/ProgressionViewModelTest.kt
+++ b/app/src/test/java/com/android/streetworkapp/model/progression/ProgressionViewModelTest.kt
@@ -27,20 +27,6 @@ class ProgressionViewModelTest {
   }
 
   @Test
-  fun createProgressionCallsRepository() = runTest {
-    progressionViewModel.createProgression("test", "test")
-    testDispatcher.scheduler.advanceUntilIdle()
-    verify(repository).createProgression("test", "test")
-  }
-
-  @Test
-  fun getProgressionCallsRepository() = runTest {
-    progressionViewModel.getCurrentProgression("test")
-    testDispatcher.scheduler.advanceUntilIdle()
-    verify(repository).getProgression(any(), any(), any())
-  }
-
-  @Test
   fun getOrAddProgressionCallsRepository() = runTest {
     progressionViewModel.getOrAddProgression("test")
     testDispatcher.scheduler.advanceUntilIdle()


### PR DESCRIPTION
**Overview**
Since the Login system changed with a new way to set the current user, a new function was added to the Progression ViewModel : `getOrAddProgression` . Since this function is a merge of the `getProgression` and the `createProgression`, this Pull Request will remove them since they are obsolete. This Pull Request also include a first instance of the gamification system, in order to check that the progression works as intended after this refactoring.

**Changes**
- Removed `getProgression` the `createProgression`
- Use `increaseUserScore` in `AddEvent`, to have our first instance of gamification, and to use/test the progression Screen

**How to Test**

1. Log in the app
2. Select any park
3. Add an event to this Park, you should receive points
4. Go to the progression screen and check that the score is higher now

(Note: the number of points given is there to easily see a difference in the progression screen, a dedicated new PR should be dedicated to use `increaseUserScore` in every places needed and with a coherent number of points)