### PR TITLE
Feat/implement text moderation with perspective api

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,6 +125,7 @@ jobs:
           KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
           KEYSTORE_ALIAS: ${{ secrets.KEYSTORE_ALIAS }}
           KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
+          PERSPECTIVE_API_KEY: ${{ secrets.PERSPECTIVE_API_KEY }}
         run: |
           # To run the CI with debug information, add --info
           ./gradlew assemble lint --parallel --build-cache

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,8 +132,6 @@ jobs:
 
       # Run Unit tests
       - name: Run Unit tests
-        env:
-          PERSPECTIVE_API_KEY: ${{ secrets.PERSPECTIVE_API_KEY }}
         run: |
           # To run the CI with debug information, add --info
           ./gradlew check --parallel --build-cache

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,6 +132,8 @@ jobs:
 
       # Run Unit tests
       - name: Run Unit tests
+        env:
+          PERSPECTIVE_API_KEY: ${{ secrets.PERSPECTIVE_API_KEY }}
         run: |
           # To run the CI with debug information, add --info
           ./gradlew check --parallel --build-cache

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -8,6 +8,7 @@ plugins {
     alias(libs.plugins.sonar)
     id("jacoco")
     alias(libs.plugins.gms) // Google services (auth)
+    kotlin("plugin.serialization") version "2.0.21"
 }
 
 android {
@@ -38,6 +39,7 @@ android {
 
 
     val mapsApiKey: String = localProperties.getProperty("MAPS_API_KEY") ?: ""
+    val perspectiveAPIKey = localProperties.getProperty("PERSPECTIVE_API_KEY")
 
     defaultConfig {
         applicationId = "com.android.streetworkapp"
@@ -51,6 +53,7 @@ android {
             useSupportLibrary = true
         }
         manifestPlaceholders["MAPS_API_KEY"] = mapsApiKey
+        buildConfigField("String", "PERSPECTIVE_API_KEY", "\"${localProperties.getProperty("PERSPECTIVE_API_KEY")}\"")
     }
 
     buildTypes {
@@ -76,6 +79,7 @@ android {
 
     buildFeatures {
         compose = true
+        buildConfig = true //so that we can use BuildConfig.{field} in code
     }
 
     composeOptions {
@@ -155,6 +159,7 @@ fun DependencyHandlerScope.globalTestImplementation(dep: Any) {
 }
 
 dependencies {
+    implementation(libs.kotlinx.serialization.json)
     implementation(libs.androidx.navigation.runtime.ktx)
     implementation(libs.androidx.navigation.compose)
     implementation (libs.androidx.material.icons.extended)
@@ -180,6 +185,7 @@ dependencies {
     globalTestImplementation(libs.androidx.junit)
     globalTestImplementation(libs.androidx.espresso.core)
     androidTestImplementation(libs.androidx.espresso.intents)
+
 
     // Testing Unit
     androidTestImplementation(libs.mockk)

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -38,8 +38,9 @@ android {
     }
 
 
+    //fetching keys
     val mapsApiKey: String = localProperties.getProperty("MAPS_API_KEY") ?: ""
-    val perspectiveAPIKey = localProperties.getProperty("PERSPECTIVE_API_KEY")
+    val perspectiveApiKey: String = System.getenv("PERSPECTIVE_API_KEY") ?: localProperties.getProperty("PERSPECTIVE_API_KEY", "")
 
     defaultConfig {
         applicationId = "com.android.streetworkapp"
@@ -52,8 +53,9 @@ android {
         vectorDrawables {
             useSupportLibrary = true
         }
+
         manifestPlaceholders["MAPS_API_KEY"] = mapsApiKey
-        buildConfigField("String", "PERSPECTIVE_API_KEY", "\"${localProperties.getProperty("PERSPECTIVE_API_KEY")}\"")
+        buildConfigField("String", "PERSPECTIVE_API_KEY", "\"${perspectiveApiKey}\"")
     }
 
     buildTypes {

--- a/app/src/main/java/com/android/streetworkapp/model/moderation/PerspectiveAPIModels.kt
+++ b/app/src/main/java/com/android/streetworkapp/model/moderation/PerspectiveAPIModels.kt
@@ -29,6 +29,14 @@ data class Comment(
 
 //Responses data classes
 @Serializable
+data class SuccessResponse(
+    val attributeScores: Map<String, AttributeScore>,
+    val languages: List<String>,
+    val detectedLanguages: List<String>
+)
+
+
+@Serializable
 data class AttributeScore(
     val spanScores: List<SpanScore>,
     val summaryScore: Score
@@ -116,5 +124,13 @@ enum class PerspectiveApiErrors(val errorMessage: String) {
      */
     JSON_DESERIALIZATION_ERROR("Failed to deserialize input from Perspective API response"),
 
-    UNSUPPORTED_HTTP_CODE("Received an unsupported HTTP code")
+    /**
+     * Received a HTTP code not included in {200, 400}
+     */
+    UNSUPPORTED_HTTP_CODE("Received an unsupported HTTP code"),
+
+    /**
+     * Received an empty body as API response
+     */
+    EMPTY_BODY_RESPONSE("Received an empty body in Perspective API response")
 }

--- a/app/src/main/java/com/android/streetworkapp/model/moderation/PerspectiveAPIModels.kt
+++ b/app/src/main/java/com/android/streetworkapp/model/moderation/PerspectiveAPIModels.kt
@@ -2,38 +2,31 @@ package com.android.streetworkapp.model.moderation
 
 import kotlinx.serialization.Serializable
 
+// All the definitions below are used to interact with Perspective API
 
-//All the definitions below are used to interact with Perspective API
-
-/**
- * Default values we can use as thresholds for our TextModerationTags
- */
-object PerspectiveAPIThresholds{
-    val DEFAULT_THRESHOLD_VALUES = TextModerationTags.entries.associateWith { 0.5 }
+/** Default values we can use as thresholds for our TextModerationTags */
+object PerspectiveAPIThresholds {
+  val DEFAULT_THRESHOLD_VALUES = TextModerationTags.entries.associateWith { 0.5 }
 }
 
-/**
- * All the tags we want to fetch from the API
- */
+/** All the tags we want to fetch from the API */
 enum class TextModerationTags {
-    TOXICITY, INSULT, THREAT
+  TOXICITY,
+  INSULT,
+  THREAT
 }
 
-/**
- * Used to store the results from the API
- */
+/** Used to store the results from the API */
 data class TagAnnotation(val tag: TextModerationTags, val probability: Double)
 
-
-/**
- * Used to return the result of a query to PerspectiveAPI
- */
+/** Used to return the result of a query to PerspectiveAPI */
 sealed class TextEvaluationResult {
-    data class Success(val annotations: List<TagAnnotation>) : TextEvaluationResult()
-    data class Error(val errorType: PerspectiveApiErrors) : TextEvaluationResult()
+  data class Success(val annotations: List<TagAnnotation>) : TextEvaluationResult()
+
+  data class Error(val errorType: PerspectiveApiErrors) : TextEvaluationResult()
 }
 
-//Request data classes
+// Request data classes
 @Serializable
 data class Request(
     val comment: Comment,
@@ -42,12 +35,9 @@ data class Request(
     val doNotStore: Boolean
 )
 
-@Serializable
-data class Comment(
-    val text: String
-)
+@Serializable data class Comment(val text: String)
 
-//Responses data classes
+// Responses data classes
 @Serializable
 data class SuccessResponse(
     val attributeScores: Map<String, AttributeScore>,
@@ -55,102 +45,62 @@ data class SuccessResponse(
     val detectedLanguages: List<String>
 )
 
+@Serializable data class AttributeScore(val spanScores: List<SpanScore>, val summaryScore: Score)
 
-@Serializable
-data class AttributeScore(
-    val spanScores: List<SpanScore>,
-    val summaryScore: Score
-)
+@Serializable data class SpanScore(val begin: Int, val end: Int, val score: Score)
 
-@Serializable
-data class SpanScore(
-    val begin: Int,
-    val end: Int,
-    val score: Score
-)
+@Serializable data class Score(val value: Double, val type: String)
 
-@Serializable
-data class Score(
-    val value: Double,
-    val type: String
-)
-
-//errors def
+// errors def
 
 @Serializable
 data class ErrorResponse(
     val code: Int,
     val message: String,
     val status: String,
-    //Note: here we ignore the 'details' from the response as we don't need (thus it is not defined)
+    // Note: here we ignore the 'details' from the response as we don't need (thus it is not
+    // defined)
 )
 
 enum class PerspectiveApiErrors(val errorMessage: String) {
-    //Official errors from the Perspective API's website
-    /**
-     * Errors related to quota limits
-     */
-    QUOTA_EXCEEDED("The request exceeds your quota."),
+  // Official errors from the Perspective API's website
+  /** Errors related to quota limits */
+  QUOTA_EXCEEDED("The request exceeds your quota."),
 
-    /**
-     * Errors related to invalid input
-     */
-    INVALID_ARGUMENT("The request contains invalid arguments."),
+  /** Errors related to invalid input */
+  INVALID_ARGUMENT("The request contains invalid arguments."),
 
-    /**
-     * Errors related to missing authorization
-     */
-    UNAUTHENTICATED("The request is missing valid authentication credentials."),
+  /** Errors related to missing authorization */
+  UNAUTHENTICATED("The request is missing valid authentication credentials."),
 
-    /**
-     * Errors related to forbidden actions
-     */
-    PERMISSION_DENIED("You do not have permission to access this resource."),
+  /** Errors related to forbidden actions */
+  PERMISSION_DENIED("You do not have permission to access this resource."),
 
-    /**
-     * Errors related to non-existent resources
-     */
-    NOT_FOUND("The specified resource was not found."),
+  /** Errors related to non-existent resources */
+  NOT_FOUND("The specified resource was not found."),
 
-    /**
-     * Errors related to exceeding allowed limits
-     */
-    RESOURCE_EXHAUSTED("You have exceeded your API limits."),
+  /** Errors related to exceeding allowed limits */
+  RESOURCE_EXHAUSTED("You have exceeded your API limits."),
 
-    /**
-     * Errors due to server issues
-     */
-    INTERNAL_ERROR("An internal error occurred in the API."),
+  /** Errors due to server issues */
+  INTERNAL_ERROR("An internal error occurred in the API."),
 
-    /**
-     * Errors related to service being unavailable
-     */
-    UNAVAILABLE("The service is currently unavailable. Please try again later."),
+  /** Errors related to service being unavailable */
+  UNAVAILABLE("The service is currently unavailable. Please try again later."),
 
-    /**
-     * Errors due to unimplemented functionality
-     */
-    UNIMPLEMENTED("The requested functionality is not implemented."),
+  /** Errors due to unimplemented functionality */
+  UNIMPLEMENTED("The requested functionality is not implemented."),
 
-    /**
-     * Unknown or unexpected errors
-     */
-    UNKNOWN_ERROR("An unknown error occurred."),
+  /** Unknown or unexpected errors */
+  UNKNOWN_ERROR("An unknown error occurred."),
 
+  // Custom errors
+  /** Failed to deserialize the response gotten from the API */
+  JSON_DESERIALIZATION_ERROR("Failed to deserialize input from Perspective API response"),
 
-    //Custom errors
-    /**
-     * Failed to deserialize the response gotten from the API
-     */
-    JSON_DESERIALIZATION_ERROR("Failed to deserialize input from Perspective API response"),
+  /** Received a HTTP code not included in {200, 400} */
+  UNSUPPORTED_HTTP_CODE("Received an unsupported HTTP code"),
 
-    /**
-     * Received a HTTP code not included in {200, 400}
-     */
-    UNSUPPORTED_HTTP_CODE("Received an unsupported HTTP code"),
-
-    /**
-     * Received an empty body as API response
-     */
-    EMPTY_BODY_RESPONSE("Received an empty body in Perspective API response")
+  /** Received an empty body as API response */
+  EMPTY_BODY_RESPONSE("Received an empty body in Perspective API response")
 }

--- a/app/src/main/java/com/android/streetworkapp/model/moderation/PerspectiveAPIModels.kt
+++ b/app/src/main/java/com/android/streetworkapp/model/moderation/PerspectiveAPIModels.kt
@@ -1,5 +1,6 @@
 package com.android.streetworkapp.model.moderation
 
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 // All the definitions below are used to interact with Perspective API
@@ -21,10 +22,10 @@ enum class TextModerationTags {
 data class TagAnnotation(val tag: TextModerationTags, val probability: Double)
 
 /** Used to return the result of a query to PerspectiveAPI */
-sealed class TextEvaluationResult {
-  data class Success(val annotations: List<TagAnnotation>) : TextEvaluationResult()
+sealed class PerspectiveAPIEvaluationResult {
+  data class Success(val annotations: List<TagAnnotation>) : PerspectiveAPIEvaluationResult()
 
-  data class Error(val errorType: PerspectiveApiErrors) : TextEvaluationResult()
+  data class Error(val errorType: PerspectiveApiErrors) : PerspectiveAPIEvaluationResult()
 }
 
 // Request data classes
@@ -53,15 +54,18 @@ data class SuccessResponse(
 @Serializable data class Score(val value: Double, val type: String)
 
 // errors def
+@Serializable data class ErrorResponse(val error: ErrorDetail)
 
 @Serializable
-data class ErrorResponse(
+data class ErrorDetail(
     val code: Int,
     val message: String,
     val status: String,
-    // Note: here we ignore the 'details' from the response as we don't need (thus it is not
-    // defined)
+    val details: List<ErrorExtraDetails>
 )
+
+@Serializable
+data class ErrorExtraDetails(@SerialName("@type") val type: String, val errorType: String)
 
 enum class PerspectiveApiErrors(val errorMessage: String) {
   // Official errors from the Perspective API's website

--- a/app/src/main/java/com/android/streetworkapp/model/moderation/PerspectiveAPIModels.kt
+++ b/app/src/main/java/com/android/streetworkapp/model/moderation/PerspectiveAPIModels.kt
@@ -1,0 +1,120 @@
+package com.android.streetworkapp.model.moderation
+
+import kotlinx.serialization.Serializable
+
+
+//All the definitions below are used to interact with Perspective API
+
+/**
+ * Used to return the result of a query to PerspectiveAPI
+ */
+sealed class TextEvaluationResult {
+    data class Success(val annotations: List<TagAnnotation>) : TextEvaluationResult()
+    data class Error(val errorType: PerspectiveApiErrors) : TextEvaluationResult()
+}
+
+//Request data classes
+@Serializable
+data class Request(
+    val comment: Comment,
+    val requestedAttributes: Map<String, Unit>,
+    val languages: List<String>,
+    val doNotStore: Boolean
+)
+
+@Serializable
+data class Comment(
+    val text: String
+)
+
+//Responses data classes
+@Serializable
+data class AttributeScore(
+    val spanScores: List<SpanScore>,
+    val summaryScore: Score
+)
+
+@Serializable
+data class SpanScore(
+    val begin: Int,
+    val end: Int,
+    val score: Score
+)
+
+@Serializable
+data class Score(
+    val value: Double,
+    val type: String
+)
+
+//errors def
+
+@Serializable
+data class ErrorResponse(
+    val code: Int,
+    val message: String,
+    val status: String,
+    //Note: here we ignore the 'details' from the response as we don't need (thus it is not defined)
+)
+
+enum class PerspectiveApiErrors(val errorMessage: String) {
+    //Official errors from the Perspective API's website
+    /**
+     * Errors related to quota limits
+     */
+    QUOTA_EXCEEDED("The request exceeds your quota."),
+
+    /**
+     * Errors related to invalid input
+     */
+    INVALID_ARGUMENT("The request contains invalid arguments."),
+
+    /**
+     * Errors related to missing authorization
+     */
+    UNAUTHENTICATED("The request is missing valid authentication credentials."),
+
+    /**
+     * Errors related to forbidden actions
+     */
+    PERMISSION_DENIED("You do not have permission to access this resource."),
+
+    /**
+     * Errors related to non-existent resources
+     */
+    NOT_FOUND("The specified resource was not found."),
+
+    /**
+     * Errors related to exceeding allowed limits
+     */
+    RESOURCE_EXHAUSTED("You have exceeded your API limits."),
+
+    /**
+     * Errors due to server issues
+     */
+    INTERNAL_ERROR("An internal error occurred in the API."),
+
+    /**
+     * Errors related to service being unavailable
+     */
+    UNAVAILABLE("The service is currently unavailable. Please try again later."),
+
+    /**
+     * Errors due to unimplemented functionality
+     */
+    UNIMPLEMENTED("The requested functionality is not implemented."),
+
+    /**
+     * Unknown or unexpected errors
+     */
+    UNKNOWN_ERROR("An unknown error occurred."),
+
+
+    //Custom errors
+    /**
+     * Failed to deserialize the response gotten from the API
+     */
+    JSON_DESERIALIZATION_ERROR("Failed to deserialize input from Perspective API response"),
+
+    UNSUPPORTED_HTTP_CODE("Received an unsupported HTTP code")
+}

--- a/app/src/main/java/com/android/streetworkapp/model/moderation/PerspectiveAPIModels.kt
+++ b/app/src/main/java/com/android/streetworkapp/model/moderation/PerspectiveAPIModels.kt
@@ -6,14 +6,15 @@ import kotlinx.serialization.Serializable
 
 /** Default values we can use as thresholds for our TextModerationTags */
 object PerspectiveAPIThresholds {
-  val DEFAULT_THRESHOLD_VALUES = TextModerationTags.entries.associateWith { 0.5 }
+  val DEFAULT_THRESHOLD_VALUES = TextModerationTags.entries.associateWith { 0.2 }
 }
 
 /** All the tags we want to fetch from the API */
 enum class TextModerationTags {
   TOXICITY,
   INSULT,
-  THREAT
+  THREAT,
+  PROFANITY
 }
 
 /** Used to store the results from the API */

--- a/app/src/main/java/com/android/streetworkapp/model/moderation/PerspectiveAPIModels.kt
+++ b/app/src/main/java/com/android/streetworkapp/model/moderation/PerspectiveAPIModels.kt
@@ -6,6 +6,26 @@ import kotlinx.serialization.Serializable
 //All the definitions below are used to interact with Perspective API
 
 /**
+ * Default values we can use as thresholds for our TextModerationTags
+ */
+object PerspectiveAPIThresholds{
+    val DEFAULT_THRESHOLD_VALUES = TextModerationTags.entries.associateWith { 0.5 }
+}
+
+/**
+ * All the tags we want to fetch from the API
+ */
+enum class TextModerationTags {
+    TOXICITY, INSULT, THREAT
+}
+
+/**
+ * Used to store the results from the API
+ */
+data class TagAnnotation(val tag: TextModerationTags, val probability: Double)
+
+
+/**
  * Used to return the result of a query to PerspectiveAPI
  */
 sealed class TextEvaluationResult {

--- a/app/src/main/java/com/android/streetworkapp/model/moderation/PerspectiveAPIRepository.kt
+++ b/app/src/main/java/com/android/streetworkapp/model/moderation/PerspectiveAPIRepository.kt
@@ -1,18 +1,37 @@
 package com.android.streetworkapp.model.moderation
 
+import android.util.Log
+import com.squareup.okhttp.RequestBody
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.decodeFromString
 import okhttp3.OkHttpClient
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.encodeToJsonElement
+import kotlinx.serialization.json.jsonObject
+import okhttp3.Request
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.RequestBody.Companion.toRequestBody
 
 class PerspectiveAPIRepository(private val client: OkHttpClient): TextModerationRepository {
     override suspend fun evaluateText(content: String): List<TagAnnotation>? {
         if (content.isEmpty())
             return null
 
+        val requestMediaType = "application/json; charset=utf-8".toMediaType()
+        val requestBody = this.formatPostRequestBody(content).toRequestBody(requestMediaType)
+
+        //TODO: parse api key
+        //note: I'm pretty sure someone could get the key by sniffing the packets, but since we can't have a backend here we are :)
+        val request = Request.Builder().url("https://commentanalyzer.googleapis.com/v1alpha1/comments:analyze?key=").post(requestBody).build()
+
+        val response = client.newCall(request).execute()
+        //TODO: check error codes here
+
+        val jsonResponseBody = Json.parseToJsonElement(response.body.toString())
+
+        //TODO: continue here
 
     }
-
     override fun formatPostRequestBody(content: String): String {
         val request = Request(
             comment = Comment(content),
@@ -24,12 +43,31 @@ class PerspectiveAPIRepository(private val client: OkHttpClient): TextModeration
         return Json.encodeToJsonElement(request).toString()
     }
 
+    override fun extractTagAndProbabilitiesFromResponseBody(responseBody: String): List<TagAnnotation>? {
+        val attributeScoresMap = Json.decodeFromString<Map<String, AttributeScore>>(responseBody)
+
+        try {
+            val tagsAnnotations = attributeScoresMap.map { (tag, attributeScore) ->
+                TagAnnotation(
+                    enumValueOf<TEXT_MODERATION_TAGS>(tag),
+                    attributeScore.summaryScore.value
+                )
+            }
+
+            return tagsAnnotations
+        } catch (e : Exception) {
+            Log.d("PerspectiveApiRepository:", "Failed to map response body into valid List<TagAnnotation>")
+            return null
+        }
+    }
 }
 
+
+//Request data classes
 @Serializable
 data class Request(
     val comment: Comment,
-    val requestedAttributes: Map<String, Unit>, // Representing each attribute as an empty object
+    val requestedAttributes: Map<String, Unit>,
     val languages: List<String>,
     val doNotStore: Boolean
 )
@@ -37,4 +75,24 @@ data class Request(
 @Serializable
 data class Comment(
     val text: String
+)
+
+//Responses data classes
+@Serializable
+data class AttributeScore(
+    val spanScores: List<SpanScore>,
+    val summaryScore: Score
+)
+
+@Serializable
+data class SpanScore(
+    val begin: Int,
+    val end: Int,
+    val score: Score
+)
+
+@Serializable
+data class Score(
+    val value: Double,
+    val type: String
 )

--- a/app/src/main/java/com/android/streetworkapp/model/moderation/PerspectiveAPIRepository.kt
+++ b/app/src/main/java/com/android/streetworkapp/model/moderation/PerspectiveAPIRepository.kt
@@ -30,7 +30,7 @@ class PerspectiveAPIRepository(private val client: OkHttpClient): TextModeration
 
         when (val result = this.getTextAnnotations(content)) {
             is TextEvaluationResult.Error -> {
-                Log.d(DEBUG_PREFIX, result.errorType.errorMessage)
+                Log.d(this.DEBUG_PREFIX, result.errorType.errorMessage)
                 return false
             }
             is TextEvaluationResult.Success -> {
@@ -50,8 +50,12 @@ class PerspectiveAPIRepository(private val client: OkHttpClient): TextModeration
 
     }
 
-    //TODO: comment what this code does in the interface
-    override fun getTextAnnotations(content: String): TextEvaluationResult {
+    /**
+     * Gets the tags and their probabilities for param content
+     * @param content Text to be analyzed
+     * @return TextEvaluationResult.Success if the API could process the content, TextEvaluationResult.Error if an error was encountered
+     */
+    private fun getTextAnnotations(content: String): TextEvaluationResult {
         //I don't perform any checks on the content, I'll let the api handle the error checking
 
         val requestMediaType = "application/json; charset=utf-8".toMediaType()

--- a/app/src/main/java/com/android/streetworkapp/model/moderation/PerspectiveAPIRepository.kt
+++ b/app/src/main/java/com/android/streetworkapp/model/moderation/PerspectiveAPIRepository.kt
@@ -15,6 +15,12 @@ import okhttp3.RequestBody.Companion.toRequestBody
 class PerspectiveAPIRepository(private val client: OkHttpClient) : TextModerationRepository {
   private val DEBUG_PREFIX = "PerspectiveAPIRepository:"
 
+    /**
+     * Evaluates the text
+     *
+     * @param content Text to be analyzed
+     * @return True if the text is under all thresholds, false if the text is over at least one threshold
+     */
   override fun evaluateText(content: String, thresholds: Map<TextModerationTags, Double>): Boolean {
     if (content.isEmpty()) return false
 

--- a/app/src/main/java/com/android/streetworkapp/model/moderation/PerspectiveAPIRepository.kt
+++ b/app/src/main/java/com/android/streetworkapp/model/moderation/PerspectiveAPIRepository.kt
@@ -2,124 +2,132 @@ package com.android.streetworkapp.model.moderation
 
 import android.util.Log
 import com.android.sample.BuildConfig
-import okhttp3.OkHttpClient
-import kotlinx.serialization.json.Json
-import kotlinx.serialization.json.encodeToJsonElement
-import okhttp3.Request
-import okhttp3.MediaType.Companion.toMediaType
-import okhttp3.RequestBody.Companion.toRequestBody
-import okhttp3.Response
 import java.net.HttpURLConnection.HTTP_BAD_REQUEST
 import java.net.HttpURLConnection.HTTP_OK
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.encodeToJsonElement
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
 
-class PerspectiveAPIRepository(private val client: OkHttpClient): TextModerationRepository {
-    private val DEBUG_PREFIX = "PerspectiveAPIRepository:"
+class PerspectiveAPIRepository(private val client: OkHttpClient) : TextModerationRepository {
+  private val DEBUG_PREFIX = "PerspectiveAPIRepository:"
 
-    override fun evaluateText(
-        content: String,
-        thresholds: Map<TextModerationTags, Double>
-    ): Boolean {
-        if (content.isEmpty())
-            return false
+  override fun evaluateText(content: String, thresholds: Map<TextModerationTags, Double>): Boolean {
+    if (content.isEmpty()) return false
 
-        when (val result = this.getTextAnnotations(content)) {
-            is TextEvaluationResult.Error -> {
-                Log.d(this.DEBUG_PREFIX, result.errorType.errorMessage)
-                return false
-            }
-            is TextEvaluationResult.Success -> {
-                for (resultAnnotation in result.annotations) {
-                    thresholds[resultAnnotation.tag]?.let { thresholdTagProbability ->
-                        if (resultAnnotation.probability > thresholdTagProbability)
-                            return false //Text over one of the thresholds
-
-                    } ?: run {
-                        return false //invalid tag
-                    }
-                }
-
-                return true //all the tags under the thresholds :)
-            }
+    when (val result = this.getTextAnnotations(content)) {
+      is TextEvaluationResult.Error -> {
+        Log.d(this.DEBUG_PREFIX, result.errorType.errorMessage)
+        return false
+      }
+      is TextEvaluationResult.Success -> {
+        for (resultAnnotation in result.annotations) {
+          thresholds[resultAnnotation.tag]?.let { thresholdTagProbability ->
+            if (resultAnnotation.probability > thresholdTagProbability)
+                return false // Text over one of the thresholds
+          }
+              ?: run {
+                return false // invalid tag
+              }
         }
 
+        return true // all the tags under the thresholds :)
+      }
     }
+  }
 
-    /**
-     * Gets the tags and their probabilities for param content
-     * @param content Text to be analyzed
-     * @return TextEvaluationResult.Success if the API could process the content, TextEvaluationResult.Error if an error was encountered
-     */
-    private fun getTextAnnotations(content: String): TextEvaluationResult {
-        //I don't perform any checks on the content, I'll let the api handle the error checking
+  /**
+   * Gets the tags and their probabilities for param content
+   *
+   * @param content Text to be analyzed
+   * @return TextEvaluationResult.Success if the API could process the content,
+   *   TextEvaluationResult.Error if an error was encountered
+   */
+  private fun getTextAnnotations(content: String): TextEvaluationResult {
+    // I don't perform any checks on the content, I'll let the api handle the error checking
 
-        val requestMediaType = "application/json; charset=utf-8".toMediaType()
-        val requestBody = this.formatPostRequestBody(content).toRequestBody(requestMediaType)
+    val requestMediaType = "application/json; charset=utf-8".toMediaType()
+    val requestBody = this.formatPostRequestBody(content).toRequestBody(requestMediaType)
 
-        //note: someone could get the key by sniffing the packets, but since we can't have a backend here we are :)
-        val request = Request.Builder().url("https://commentanalyzer.googleapis.com/v1alpha1/comments:analyze?key=${BuildConfig.PERSPECTIVE_API_KEY}").post(requestBody).build()
+    // note: someone could get the key by sniffing the packets, but since we can't have a backend
+    // here we are :)
+    val request =
+        Request.Builder()
+            .url(
+                "https://commentanalyzer.googleapis.com/v1alpha1/comments:analyze?key=${BuildConfig.PERSPECTIVE_API_KEY}")
+            .post(requestBody)
+            .build()
 
-        val response = client.newCall(request).execute()
-        when(response.code) {
-            HTTP_OK -> {
-                val responseBody = response.body?.string() ?: run { return TextEvaluationResult.Error(PerspectiveApiErrors.EMPTY_BODY_RESPONSE) }
-                val annotations = this.extractTagsAndProbabilitiesFromResponseBody(responseBody)
-                annotations?.let {
-                    return TextEvaluationResult.Success(annotations)
-                } ?: run {
-                    return TextEvaluationResult.Error(PerspectiveApiErrors.JSON_DESERIALIZATION_ERROR)
+    val response = client.newCall(request).execute()
+    when (response.code) {
+      HTTP_OK -> {
+        val responseBody =
+            response.body?.string()
+                ?: run {
+                  return TextEvaluationResult.Error(PerspectiveApiErrors.EMPTY_BODY_RESPONSE)
                 }
-            }
-            HTTP_BAD_REQUEST -> {
-                val responseBody = response.body?.string() ?: run { return TextEvaluationResult.Error(PerspectiveApiErrors.EMPTY_BODY_RESPONSE) }
-                val error = extractErrorFromResponseBody(responseBody)
-                return TextEvaluationResult.Error(error)
-            }
-            else -> {
-                Log.d(this.DEBUG_PREFIX, "Received unsupported http code (${response.code}) from api")
-                return TextEvaluationResult.Error(PerspectiveApiErrors.UNSUPPORTED_HTTP_CODE)
-            }
+        val annotations = this.extractTagsAndProbabilitiesFromResponseBody(responseBody)
+        annotations?.let {
+          return TextEvaluationResult.Success(annotations)
         }
+            ?: run {
+              return TextEvaluationResult.Error(PerspectiveApiErrors.JSON_DESERIALIZATION_ERROR)
+            }
+      }
+      HTTP_BAD_REQUEST -> {
+        val responseBody =
+            response.body?.string()
+                ?: run {
+                  return TextEvaluationResult.Error(PerspectiveApiErrors.EMPTY_BODY_RESPONSE)
+                }
+        val error = extractErrorFromResponseBody(responseBody)
+        return TextEvaluationResult.Error(error)
+      }
+      else -> {
+        Log.d(this.DEBUG_PREFIX, "Received unsupported http code (${response.code}) from api")
+        return TextEvaluationResult.Error(PerspectiveApiErrors.UNSUPPORTED_HTTP_CODE)
+      }
     }
+  }
 
-    private fun formatPostRequestBody(content: String): String {
-        val request = Request(
+  private fun formatPostRequestBody(content: String): String {
+    val request =
+        Request(
             comment = Comment(content),
             requestedAttributes = TextModerationTags.entries.associate { it.name to Unit },
-            languages = emptyList(), //we don't know the input language, we'll let the api decide
-            doNotStore = true //we don't want the api to store our inputs
+            languages = emptyList(), // we don't know the input language, we'll let the api decide
+            doNotStore = true // we don't want the api to store our inputs
             )
 
-        return Json.encodeToJsonElement(request).toString()
-    }
+    return Json.encodeToJsonElement(request).toString()
+  }
 
-    private fun extractTagsAndProbabilitiesFromResponseBody(responseBody: String): List<TagAnnotation>? {
-        try {
-            val attributeScoresMap = Json.decodeFromString<SuccessResponse>(responseBody).attributeScores
-            val tagsAnnotations = attributeScoresMap.map { (tag, attributeScore) ->
-                TagAnnotation(
-                    enumValueOf<TextModerationTags>(tag),
-                    attributeScore.summaryScore.value
-                )
-            }
+  private fun extractTagsAndProbabilitiesFromResponseBody(
+      responseBody: String
+  ): List<TagAnnotation>? {
+    try {
+      val attributeScoresMap = Json.decodeFromString<SuccessResponse>(responseBody).attributeScores
+      val tagsAnnotations =
+          attributeScoresMap.map { (tag, attributeScore) ->
+            TagAnnotation(enumValueOf<TextModerationTags>(tag), attributeScore.summaryScore.value)
+          }
 
-            return tagsAnnotations
-        } catch (e : Exception) {
-            Log.d(this.DEBUG_PREFIX, "Failed to map response body into valid List<TagAnnotation>")
-            return null
-        }
+      return tagsAnnotations
+    } catch (e: Exception) {
+      Log.d(this.DEBUG_PREFIX, "Failed to map response body into valid List<TagAnnotation>")
+      return null
     }
+  }
 
-    private fun extractErrorFromResponseBody(responseBody: String): PerspectiveApiErrors {
-        try {
-            val error = Json.decodeFromString<ErrorResponse>(responseBody)
-            return enumValues<PerspectiveApiErrors>().find { it.name == error.status }
-                ?: PerspectiveApiErrors.UNKNOWN_ERROR
-        } catch (e: Exception) {
-            return PerspectiveApiErrors.JSON_DESERIALIZATION_ERROR
-        }
+  private fun extractErrorFromResponseBody(responseBody: String): PerspectiveApiErrors {
+    try {
+      val error = Json.decodeFromString<ErrorResponse>(responseBody)
+      return enumValues<PerspectiveApiErrors>().find { it.name == error.status }
+          ?: PerspectiveApiErrors.UNKNOWN_ERROR
+    } catch (e: Exception) {
+      return PerspectiveApiErrors.JSON_DESERIALIZATION_ERROR
     }
+  }
 }
-
-
-
-

--- a/app/src/main/java/com/android/streetworkapp/model/moderation/PerspectiveAPIRepository.kt
+++ b/app/src/main/java/com/android/streetworkapp/model/moderation/PerspectiveAPIRepository.kt
@@ -6,6 +6,7 @@ import java.net.HttpURLConnection.HTTP_BAD_REQUEST
 import java.net.HttpURLConnection.HTTP_OK
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.encodeToJsonElement
+import okhttp3.HttpUrl
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
 import okhttp3.Request
@@ -53,12 +54,16 @@ class PerspectiveAPIRepository(private val client: OkHttpClient) : TextModeratio
 
     // note: someone could get the key by sniffing the packets, but since we can't have a backend
     // here we are :)
-    val request =
-        Request.Builder()
-            .url(
-                "https://commentanalyzer.googleapis.com/v1alpha1/comments:analyze?key=${BuildConfig.PERSPECTIVE_API_KEY}")
-            .post(requestBody)
+    val url =
+        HttpUrl.Builder()
+            .scheme("https")
+            .host("commentanalyzer.googleapis.com")
+            .addPathSegment("v1alpha1")
+            .addPathSegment("comments:analyze")
+            .addQueryParameter("key", BuildConfig.PERSPECTIVE_API_KEY)
             .build()
+
+    val request = Request.Builder().url(url).post(requestBody).build()
 
     val response = client.newCall(request).execute()
     when (response.code) {

--- a/app/src/main/java/com/android/streetworkapp/model/moderation/PerspectiveAPIRepository.kt
+++ b/app/src/main/java/com/android/streetworkapp/model/moderation/PerspectiveAPIRepository.kt
@@ -2,6 +2,7 @@ package com.android.streetworkapp.model.moderation
 
 import android.util.Log
 import androidx.compose.material3.Text
+import com.android.sample.BuildConfig
 import com.squareup.okhttp.RequestBody
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.decodeFromString
@@ -19,7 +20,7 @@ import java.net.HttpURLConnection.HTTP_OK
 class PerspectiveAPIRepository(private val client: OkHttpClient): TextModerationRepository {
     private val DEBUG_PREFIX = "PerspectiveAPIRepository:"
 
-    override suspend fun evaluateText(content: String): TextEvaluationResult {
+    override fun evaluateText(content: String): TextEvaluationResult {
         //I don't perform any checks on the content, I'll let the api handle the error checking
 
         val requestMediaType = "application/json; charset=utf-8".toMediaType()
@@ -27,12 +28,13 @@ class PerspectiveAPIRepository(private val client: OkHttpClient): TextModeration
 
         //TODO: parse api key
         //note: I'm pretty sure someone could get the key by sniffing the packets, but since we can't have a backend here we are :)
-        val request = Request.Builder().url("https://commentanalyzer.googleapis.com/v1alpha1/comments:analyze?key=").post(requestBody).build()
+        val request = Request.Builder().url("https://commentanalyzer.googleapis.com/v1alpha1/comments:analyze?key=${BuildConfig.PERSPECTIVE_API_KEY}").post(requestBody).build()
 
         val response = client.newCall(request).execute()
         when(response.code) {
             HTTP_OK -> {
-                val annotations = this.extractTagsAndProbabilitiesFromResponseBody(response.body.toString())
+                val responseBody = response.body?.string() ?: run { return TextEvaluationResult.Error(PerspectiveApiErrors.EMPTY_BODY_RESPONSE) }
+                val annotations = this.extractTagsAndProbabilitiesFromResponseBody(responseBody)
                 annotations?.let {
                     return TextEvaluationResult.Success(annotations)
                 } ?: run {
@@ -44,12 +46,13 @@ class PerspectiveAPIRepository(private val client: OkHttpClient): TextModeration
                 return TextEvaluationResult.Error(enumValues<PerspectiveApiErrors>().find { it.name == error.status  } ?: PerspectiveApiErrors.UNKNOWN_ERROR)
             }
             else -> {
-                Log.d(DEBUG_PREFIX, "Received unsupported http code (${response.code}) from api")
+                Log.d(this.DEBUG_PREFIX, "Received unsupported http code (${response.code}) from api")
                 return TextEvaluationResult.Error(PerspectiveApiErrors.UNSUPPORTED_HTTP_CODE)
             }
         }
     }
-    override fun formatPostRequestBody(content: String): String {
+
+    private fun formatPostRequestBody(content: String): String {
         val request = Request(
             comment = Comment(content),
             requestedAttributes = TEXT_MODERATION_TAGS.entries.associate { it.name to Unit },
@@ -60,10 +63,9 @@ class PerspectiveAPIRepository(private val client: OkHttpClient): TextModeration
         return Json.encodeToJsonElement(request).toString()
     }
 
-    override fun extractTagsAndProbabilitiesFromResponseBody(responseBody: String): List<TagAnnotation>? {
-        val attributeScoresMap = Json.decodeFromString<Map<String, AttributeScore>>(responseBody)
-
+    private fun extractTagsAndProbabilitiesFromResponseBody(responseBody: String): List<TagAnnotation>? {
         try {
+            val attributeScoresMap = Json.decodeFromString<SuccessResponse>(responseBody).attributeScores
             val tagsAnnotations = attributeScoresMap.map { (tag, attributeScore) ->
                 TagAnnotation(
                     enumValueOf<TEXT_MODERATION_TAGS>(tag),
@@ -73,7 +75,7 @@ class PerspectiveAPIRepository(private val client: OkHttpClient): TextModeration
 
             return tagsAnnotations
         } catch (e : Exception) {
-            Log.d("PerspectiveApiRepository:", "Failed to map response body into valid List<TagAnnotation>")
+            Log.d(this.DEBUG_PREFIX, "Failed to map response body into valid List<TagAnnotation>")
             return null
         }
     }

--- a/app/src/main/java/com/android/streetworkapp/model/moderation/PerspectiveAPIRepository.kt
+++ b/app/src/main/java/com/android/streetworkapp/model/moderation/PerspectiveAPIRepository.kt
@@ -1,0 +1,40 @@
+package com.android.streetworkapp.model.moderation
+
+import kotlinx.serialization.Serializable
+import okhttp3.OkHttpClient
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.encodeToJsonElement
+
+class PerspectiveAPIRepository(private val client: OkHttpClient): TextModerationRepository {
+    override suspend fun evaluateText(content: String): List<TagAnnotation>? {
+        if (content.isEmpty())
+            return null
+
+
+    }
+
+    override fun formatPostRequestBody(content: String): String {
+        val request = Request(
+            comment = Comment(content),
+            requestedAttributes = TEXT_MODERATION_TAGS.entries.associate { it.name to Unit },
+            languages = emptyList(), //we don't know the input language, we'll let the api decide
+            doNotStore = true //we don't want the api to store our inputs
+            )
+
+        return Json.encodeToJsonElement(request).toString()
+    }
+
+}
+
+@Serializable
+data class Request(
+    val comment: Comment,
+    val requestedAttributes: Map<String, Unit>, // Representing each attribute as an empty object
+    val languages: List<String>,
+    val doNotStore: Boolean
+)
+
+@Serializable
+data class Comment(
+    val text: String
+)

--- a/app/src/main/java/com/android/streetworkapp/model/moderation/TextModerationRepository.kt
+++ b/app/src/main/java/com/android/streetworkapp/model/moderation/TextModerationRepository.kt
@@ -8,11 +8,4 @@ interface TextModerationRepository {
      * @return True if the text is under the thresholds for all tags, false otherwise
      */
     fun evaluateText(content: String, thresholds: Map<TextModerationTags, Double>): Boolean
-
-    /**
-     * Gets the tags and their probabilities for param content
-     * @param content Text to be analyzed
-     * @return TextEvaluationResult.Success if the API could process the content, TextEvaluationResult.Error if an error was encountered
-     */
-    fun getTextAnnotations(content: String): TextEvaluationResult
 }

--- a/app/src/main/java/com/android/streetworkapp/model/moderation/TextModerationRepository.kt
+++ b/app/src/main/java/com/android/streetworkapp/model/moderation/TextModerationRepository.kt
@@ -9,5 +9,5 @@ interface TextModerationRepository {
    *   probability of the text being included in this tag, ranges from 0-1.
    * @return True if the text is under the thresholds for all tags, false otherwise
    */
-  fun evaluateText(content: String, thresholds: Map<TextModerationTags, Double>): Boolean
+  fun evaluateText(content: String, thresholds: Map<TextModerationTags, Double>): TextEvaluation
 }

--- a/app/src/main/java/com/android/streetworkapp/model/moderation/TextModerationRepository.kt
+++ b/app/src/main/java/com/android/streetworkapp/model/moderation/TextModerationRepository.kt
@@ -1,0 +1,6 @@
+package com.android.streetworkapp.model.moderation
+
+interface TextModerationRepository {
+    suspend fun evaluateText(content: String): List<TagAnnotation>?
+    fun formatPostRequestBody(content: String) : String
+}

--- a/app/src/main/java/com/android/streetworkapp/model/moderation/TextModerationRepository.kt
+++ b/app/src/main/java/com/android/streetworkapp/model/moderation/TextModerationRepository.kt
@@ -1,7 +1,7 @@
 package com.android.streetworkapp.model.moderation
 
 interface TextModerationRepository {
-    suspend fun evaluateText(content: String): List<TagAnnotation>?
+    suspend fun evaluateText(content: String): TextEvaluationResult
     fun formatPostRequestBody(content: String): String
-    fun extractTagAndProbabilitiesFromResponseBody(responseBody: String): List<TagAnnotation>?
+    fun extractTagsAndProbabilitiesFromResponseBody(responseBody: String): List<TagAnnotation>?
 }

--- a/app/src/main/java/com/android/streetworkapp/model/moderation/TextModerationRepository.kt
+++ b/app/src/main/java/com/android/streetworkapp/model/moderation/TextModerationRepository.kt
@@ -2,5 +2,6 @@ package com.android.streetworkapp.model.moderation
 
 interface TextModerationRepository {
     suspend fun evaluateText(content: String): List<TagAnnotation>?
-    fun formatPostRequestBody(content: String) : String
+    fun formatPostRequestBody(content: String): String
+    fun extractTagAndProbabilitiesFromResponseBody(responseBody: String): List<TagAnnotation>?
 }

--- a/app/src/main/java/com/android/streetworkapp/model/moderation/TextModerationRepository.kt
+++ b/app/src/main/java/com/android/streetworkapp/model/moderation/TextModerationRepository.kt
@@ -1,7 +1,5 @@
 package com.android.streetworkapp.model.moderation
 
 interface TextModerationRepository {
-    suspend fun evaluateText(content: String): TextEvaluationResult
-    fun formatPostRequestBody(content: String): String
-    fun extractTagsAndProbabilitiesFromResponseBody(responseBody: String): List<TagAnnotation>?
+    fun evaluateText(content: String): TextEvaluationResult
 }

--- a/app/src/main/java/com/android/streetworkapp/model/moderation/TextModerationRepository.kt
+++ b/app/src/main/java/com/android/streetworkapp/model/moderation/TextModerationRepository.kt
@@ -1,11 +1,13 @@
 package com.android.streetworkapp.model.moderation
 
 interface TextModerationRepository {
-    /**
-     * Analyses the content, returns true if the content is under the threshold, false otherwise
-     * @param content The text to be analyzed
-     * @param thresholds A map that holds the threshold values for each tags. Each threshold is the probability of the text being included in this tag, ranges from 0-1.
-     * @return True if the text is under the thresholds for all tags, false otherwise
-     */
-    fun evaluateText(content: String, thresholds: Map<TextModerationTags, Double>): Boolean
+  /**
+   * Analyses the content, returns true if the content is under the threshold, false otherwise
+   *
+   * @param content The text to be analyzed
+   * @param thresholds A map that holds the threshold values for each tags. Each threshold is the
+   *   probability of the text being included in this tag, ranges from 0-1.
+   * @return True if the text is under the thresholds for all tags, false otherwise
+   */
+  fun evaluateText(content: String, thresholds: Map<TextModerationTags, Double>): Boolean
 }

--- a/app/src/main/java/com/android/streetworkapp/model/moderation/TextModerationRepository.kt
+++ b/app/src/main/java/com/android/streetworkapp/model/moderation/TextModerationRepository.kt
@@ -1,5 +1,18 @@
 package com.android.streetworkapp.model.moderation
 
 interface TextModerationRepository {
-    fun evaluateText(content: String): TextEvaluationResult
+    /**
+     * Analyses the content, returns true if the content is under the threshold, false otherwise
+     * @param content The text to be analyzed
+     * @param thresholds A map that holds the threshold values for each tags. Each threshold is the probability of the text being included in this tag, ranges from 0-1.
+     * @return True if the text is under the thresholds for all tags, false otherwise
+     */
+    fun evaluateText(content: String, thresholds: Map<TextModerationTags, Double>): Boolean
+
+    /**
+     * Gets the tags and their probabilities for param content
+     * @param content Text to be analyzed
+     * @return TextEvaluationResult.Success if the API could process the content, TextEvaluationResult.Error if an error was encountered
+     */
+    fun getTextAnnotations(content: String): TextEvaluationResult
 }

--- a/app/src/main/java/com/android/streetworkapp/model/moderation/TextModerationViewModel.kt
+++ b/app/src/main/java/com/android/streetworkapp/model/moderation/TextModerationViewModel.kt
@@ -1,13 +1,20 @@
 package com.android.streetworkapp.model.moderation
 
-class TextModerationViewModel {
+import android.util.Log
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.launch
 
+class TextModerationViewModel(val repository: TextModerationRepository): ViewModel() {
+    fun analyzeText(content: String, onTextUnderThresholds: () -> Unit, onTextOverThresholds: () -> Unit, thresholds: Map<TextModerationTags, Double> = PerspectiveAPIThresholds.DEFAULT_THRESHOLD_VALUES): Boolean {
+        viewModelScope.launch {
+            if (repository.evaluateText(content, thresholds))
+                onTextUnderThresholds()
+            else
+                onTextOverThresholds()
+        }
+    }
 }
 
 
-
-data class TagAnnotation(val tag: TEXT_MODERATION_TAGS, val probability: Double)
-
-enum class TEXT_MODERATION_TAGS {
-    TOXICITY, INSULT, THREAT
-}

--- a/app/src/main/java/com/android/streetworkapp/model/moderation/TextModerationViewModel.kt
+++ b/app/src/main/java/com/android/streetworkapp/model/moderation/TextModerationViewModel.kt
@@ -1,0 +1,12 @@
+package com.android.streetworkapp.model.moderation
+
+class TextModerationViewModel {
+
+}
+
+
+data class TagAnnotation(val tag: TEXT_MODERATION_TAGS, val probability: Double)
+
+enum class TEXT_MODERATION_TAGS {
+    TOXICITY, INSULT, THREAT
+}

--- a/app/src/main/java/com/android/streetworkapp/model/moderation/TextModerationViewModel.kt
+++ b/app/src/main/java/com/android/streetworkapp/model/moderation/TextModerationViewModel.kt
@@ -6,8 +6,8 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.launch
 
-class TextModerationViewModel(val repository: TextModerationRepository): ViewModel() {
-    fun analyzeText(content: String, onTextUnderThresholds: () -> Unit, onTextOverThresholds: () -> Unit, thresholds: Map<TextModerationTags, Double> = PerspectiveAPIThresholds.DEFAULT_THRESHOLD_VALUES): Boolean {
+open class TextModerationViewModel(val repository: TextModerationRepository): ViewModel() {
+    fun analyzeText(content: String, onTextUnderThresholds: () -> Unit, onTextOverThresholds: () -> Unit, thresholds: Map<TextModerationTags, Double> = PerspectiveAPIThresholds.DEFAULT_THRESHOLD_VALUES) {
         viewModelScope.launch {
             if (repository.evaluateText(content, thresholds))
                 onTextUnderThresholds()

--- a/app/src/main/java/com/android/streetworkapp/model/moderation/TextModerationViewModel.kt
+++ b/app/src/main/java/com/android/streetworkapp/model/moderation/TextModerationViewModel.kt
@@ -5,6 +5,18 @@ import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.launch
 
 open class TextModerationViewModel(val repository: TextModerationRepository) : ViewModel() {
+  /**
+   * Analyzes the given text (`content`) against specified thresholds to determine if it meets
+   * moderation criteria.
+   *
+   * @param content The text to be analyzed.
+   * @param onTextUnderThresholds A callback function to be executed if the text is considered clean
+   *   (under the thresholds).
+   * @param onTextOverThresholds A callback function to be executed if the text exceeds the
+   *   thresholds.
+   * @param thresholds A map of threshold values for different text moderation tags. If not
+   *   provided, default values are used.
+   */
   fun analyzeText(
       content: String,
       onTextUnderThresholds: () -> Unit,

--- a/app/src/main/java/com/android/streetworkapp/model/moderation/TextModerationViewModel.kt
+++ b/app/src/main/java/com/android/streetworkapp/model/moderation/TextModerationViewModel.kt
@@ -1,20 +1,20 @@
 package com.android.streetworkapp.model.moderation
 
-import android.util.Log
-import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.launch
 
-open class TextModerationViewModel(val repository: TextModerationRepository): ViewModel() {
-    fun analyzeText(content: String, onTextUnderThresholds: () -> Unit, onTextOverThresholds: () -> Unit, thresholds: Map<TextModerationTags, Double> = PerspectiveAPIThresholds.DEFAULT_THRESHOLD_VALUES) {
-        viewModelScope.launch {
-            if (repository.evaluateText(content, thresholds))
-                onTextUnderThresholds()
-            else
-                onTextOverThresholds()
-        }
+open class TextModerationViewModel(val repository: TextModerationRepository) : ViewModel() {
+  fun analyzeText(
+      content: String,
+      onTextUnderThresholds: () -> Unit,
+      onTextOverThresholds: () -> Unit,
+      thresholds: Map<TextModerationTags, Double> =
+          PerspectiveAPIThresholds.DEFAULT_THRESHOLD_VALUES
+  ) {
+    viewModelScope.launch {
+      if (repository.evaluateText(content, thresholds)) onTextUnderThresholds()
+      else onTextOverThresholds()
     }
+  }
 }
-
-

--- a/app/src/main/java/com/android/streetworkapp/model/moderation/TextModerationViewModel.kt
+++ b/app/src/main/java/com/android/streetworkapp/model/moderation/TextModerationViewModel.kt
@@ -5,6 +5,7 @@ class TextModerationViewModel {
 }
 
 
+
 data class TagAnnotation(val tag: TEXT_MODERATION_TAGS, val probability: Double)
 
 enum class TEXT_MODERATION_TAGS {

--- a/app/src/test/java/com/android/streetworkapp/model/textmoderation/PerspectiveAPIRepositoryTest.kt
+++ b/app/src/test/java/com/android/streetworkapp/model/textmoderation/PerspectiveAPIRepositoryTest.kt
@@ -1,0 +1,258 @@
+package com.android.streetworkapp.model.textmoderation
+
+import com.android.streetworkapp.model.moderation.PerspectiveAPIRepository
+import com.android.streetworkapp.model.moderation.PerspectiveAPIThresholds
+import com.android.streetworkapp.model.moderation.TextModerationTags
+import java.net.HttpURLConnection.HTTP_BAD_REQUEST
+import java.net.HttpURLConnection.HTTP_OK
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import okhttp3.Call
+import okhttp3.OkHttpClient
+import okhttp3.Response
+import okhttp3.ResponseBody
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.MockitoAnnotations
+import org.mockito.kotlin.any
+import org.mockito.kotlin.whenever
+
+class PerspectiveAPIRepositoryTest {
+
+  @Mock private lateinit var okHttpClient: OkHttpClient
+  @Mock private lateinit var response: Response
+  @Mock private lateinit var call: Call
+  @Mock private lateinit var responseBody: ResponseBody
+
+  @InjectMocks private lateinit var perspectiveAPIRepository: PerspectiveAPIRepository
+
+  // API responses
+  private val PERSPECTIVE_API_INVALID_REQUEST_RESPONSE =
+      """{
+        "error": {
+        "code": 400,
+        "message": "Comment must be non-empty.",
+        "status": "INVALID_ARGUMENT",
+        "details": [
+        {
+            "@type": "type.googleapis.com/google.commentanalyzer.v1alpha1.Error",
+            "errorType": "COMMENT_EMPTY"
+        }
+        ]
+    }
+    }"""
+
+  private val PERSPECTIVE_API_VALID_RESPONSE_UNDER_THRESHOLDS =
+      """{
+    "attributeScores": {
+        "TOXICITY": {
+            "spanScores": [
+                {
+                    "begin": 0,
+                    "end": 5,
+                    "score": {
+                        "value": 0.017341165,
+                        "type": "PROBABILITY"
+                    }
+                }
+            ],
+            "summaryScore": {
+                "value": 0.00,
+                "type": "PROBABILITY"
+            }
+        },
+        "THREAT": {
+            "spanScores": [
+                {
+                    "begin": 0,
+                    "end": 5,
+                    "score": {
+                        "value": 0.008427517,
+                        "type": "PROBABILITY"
+                    }
+                }
+            ],
+            "summaryScore": {
+                "value": 0.00,
+                "type": "PROBABILITY"
+            }
+        },
+        "INSULT": {
+            "spanScores": [
+                {
+                    "begin": 0,
+                    "end": 5,
+                    "score": {
+                        "value": 0.009051885,
+                        "type": "PROBABILITY"
+                    }
+                }
+            ],
+            "summaryScore": {
+                "value": 0.00,
+                "type": "PROBABILITY"
+            }
+        }
+    },
+    "languages": [
+        "en"
+    ],
+    "detectedLanguages": [
+        "en"
+    ]
+}"""
+
+  private val PERSPECTIVE_API_VALID_VALID_RESPONSE_OVER_THRESHOLDS =
+      """{
+    "attributeScores": {
+        "TOXICITY": {
+            "spanScores": [
+                {
+                    "begin": 0,
+                    "end": 5,
+                    "score": {
+                        "value": ${0.5* (1.0 + PerspectiveAPIThresholds.DEFAULT_THRESHOLD_VALUES[TextModerationTags.TOXICITY]!!)},
+                        "type": "PROBABILITY"
+                    }
+                }
+            ],
+            "summaryScore": {
+                "value": ${0.5* (1.0 + PerspectiveAPIThresholds.DEFAULT_THRESHOLD_VALUES[TextModerationTags.TOXICITY]!!)},
+                "type": "PROBABILITY"
+            }
+        },
+        "THREAT": {
+            "spanScores": [
+                {
+                    "begin": 0,
+                    "end": 5,
+                    "score": {
+                        "value": ${0.5* (1.0 + PerspectiveAPIThresholds.DEFAULT_THRESHOLD_VALUES[TextModerationTags.THREAT]!!)},
+                        "type": "PROBABILITY"
+                    }
+                }
+            ],
+            "summaryScore": {
+                "value": ${0.5* (1.0 + PerspectiveAPIThresholds.DEFAULT_THRESHOLD_VALUES[TextModerationTags.THREAT]!!)},
+                "type": "PROBABILITY"
+            }
+        },
+        "INSULT": {
+            "spanScores": [
+                {
+                    "begin": 0,
+                    "end": 5,
+                    "score": {
+                        "value": ${0.5* (1.0 + PerspectiveAPIThresholds.DEFAULT_THRESHOLD_VALUES[TextModerationTags.INSULT]!!)},
+                        "type": "PROBABILITY"
+                    }
+                }
+            ],
+            "summaryScore": {
+                "value": ${0.5* (1.0 + PerspectiveAPIThresholds.DEFAULT_THRESHOLD_VALUES[TextModerationTags.INSULT]!!)},
+                "type": "PROBABILITY"
+            }
+        }
+    },
+    "languages": [
+        "en"
+    ],
+    "detectedLanguages": [
+        "en"
+    ]
+}"""
+
+  @OptIn(ExperimentalCoroutinesApi::class)
+  @Before
+  fun setUp() {
+    Dispatchers.setMain(Dispatchers.Unconfined)
+    MockitoAnnotations.openMocks(this)
+  }
+
+  @OptIn(ExperimentalCoroutinesApi::class)
+  @After
+  fun cleanUp() {
+    Dispatchers.resetMain()
+  }
+
+  @Test
+  fun evaluateTextReturnsFalseOnUnhandledHTPPResponseCode() {
+    whenever(okHttpClient.newCall(any())).thenReturn(call)
+    whenever(call.execute()).thenReturn(response)
+    whenever(response.code).thenReturn(-1)
+
+    assert(
+        !perspectiveAPIRepository.evaluateText(
+            "content", PerspectiveAPIThresholds.DEFAULT_THRESHOLD_VALUES))
+  }
+
+  @Test
+  fun evaluateTextReturnsFalseOnAPIResponseError() {
+    whenever(okHttpClient.newCall(any())).thenReturn(call)
+    whenever(call.execute()).thenReturn(response)
+    whenever(response.code).thenReturn(HTTP_BAD_REQUEST)
+    whenever(response.body).thenReturn(responseBody)
+    whenever(responseBody.string()).thenReturn(PERSPECTIVE_API_INVALID_REQUEST_RESPONSE)
+
+    assert(
+        !perspectiveAPIRepository.evaluateText(
+            "content", PerspectiveAPIThresholds.DEFAULT_THRESHOLD_VALUES))
+  }
+
+  @Test
+  fun evaluateTextReturnsFalseOnAPIResponseErrorAndDeserializationError() {
+    whenever(okHttpClient.newCall(any())).thenReturn(call)
+    whenever(call.execute()).thenReturn(response)
+    whenever(response.code).thenReturn(HTTP_BAD_REQUEST)
+    whenever(response.body).thenReturn(responseBody)
+    whenever(responseBody.string()).thenReturn("###@@@#§") // making the deserialization fail
+
+    assert(
+        !perspectiveAPIRepository.evaluateText(
+            "content", PerspectiveAPIThresholds.DEFAULT_THRESHOLD_VALUES))
+  }
+
+  @Test
+  fun evaluateTextReturnsFalseOnAPIResponseSuccessAndDeserializationError() {
+    whenever(okHttpClient.newCall(any())).thenReturn(call)
+    whenever(call.execute()).thenReturn(response)
+    whenever(response.code).thenReturn(HTTP_OK)
+    whenever(response.body).thenReturn(responseBody)
+    whenever(responseBody.string()).thenReturn("###@@@#§") // making the deserialization fail
+
+    assert(
+        !perspectiveAPIRepository.evaluateText(
+            "content", PerspectiveAPIThresholds.DEFAULT_THRESHOLD_VALUES))
+  }
+
+  @Test
+  fun evaluateTextReturnsTrueOnAPIResponseSuccessAndUnderThresholdValues() {
+    whenever(okHttpClient.newCall(any())).thenReturn(call)
+    whenever(call.execute()).thenReturn(response)
+    whenever(response.code).thenReturn(HTTP_OK)
+    whenever(response.body).thenReturn(responseBody)
+    whenever(responseBody.string()).thenReturn(PERSPECTIVE_API_VALID_RESPONSE_UNDER_THRESHOLDS)
+
+    assert(
+        perspectiveAPIRepository.evaluateText(
+            "content", PerspectiveAPIThresholds.DEFAULT_THRESHOLD_VALUES))
+  }
+
+  @Test
+  fun evaluateTextReturnsFalseOnAPIResponseSuccessAndOverThresholdValues() {
+    whenever(okHttpClient.newCall(any())).thenReturn(call)
+    whenever(call.execute()).thenReturn(response)
+    whenever(response.code).thenReturn(HTTP_OK)
+    whenever(response.body).thenReturn(responseBody)
+    whenever(responseBody.string()).thenReturn(PERSPECTIVE_API_VALID_VALID_RESPONSE_OVER_THRESHOLDS)
+
+    assert(
+        !perspectiveAPIRepository.evaluateText(
+            "content", PerspectiveAPIThresholds.DEFAULT_THRESHOLD_VALUES))
+  }
+}

--- a/app/src/test/java/com/android/streetworkapp/model/textmoderation/PerspectiveAPIRepositoryTest.kt
+++ b/app/src/test/java/com/android/streetworkapp/model/textmoderation/PerspectiveAPIRepositoryTest.kt
@@ -255,4 +255,12 @@ class PerspectiveAPIRepositoryTest {
         !perspectiveAPIRepository.evaluateText(
             "content", PerspectiveAPIThresholds.DEFAULT_THRESHOLD_VALUES))
   }
+
+  // TODO: remove
+  @Test
+  fun temp() {
+    val repo = PerspectiveAPIRepository(OkHttpClient())
+    val temp = repo.evaluateText("content", PerspectiveAPIThresholds.DEFAULT_THRESHOLD_VALUES)
+    assert(temp)
+  }
 }

--- a/app/src/test/java/com/android/streetworkapp/model/textmoderation/PerspectiveAPIRepositoryTest.kt
+++ b/app/src/test/java/com/android/streetworkapp/model/textmoderation/PerspectiveAPIRepositoryTest.kt
@@ -255,12 +255,4 @@ class PerspectiveAPIRepositoryTest {
         !perspectiveAPIRepository.evaluateText(
             "content", PerspectiveAPIThresholds.DEFAULT_THRESHOLD_VALUES))
   }
-
-  // TODO: remove
-  @Test
-  fun temp() {
-    val repo = PerspectiveAPIRepository(OkHttpClient())
-    val temp = repo.evaluateText("content", PerspectiveAPIThresholds.DEFAULT_THRESHOLD_VALUES)
-    assert(temp)
-  }
 }

--- a/app/src/test/java/com/android/streetworkapp/model/textmoderation/TextModerationViewModelTest.kt
+++ b/app/src/test/java/com/android/streetworkapp/model/textmoderation/TextModerationViewModelTest.kt
@@ -1,0 +1,55 @@
+package com.android.streetworkapp.model.textmoderation
+
+import com.android.streetworkapp.model.moderation.TextModerationRepository
+import com.android.streetworkapp.model.moderation.TextModerationViewModel
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.Mockito.mock
+import org.mockito.MockitoAnnotations
+import org.mockito.kotlin.any
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+class TextModerationViewModelTest {
+
+  @Mock private lateinit var textModerationRepository: TextModerationRepository
+  @InjectMocks private lateinit var textModerationViewModel: TextModerationViewModel
+
+  @OptIn(ExperimentalCoroutinesApi::class)
+  @Before
+  fun setUp() {
+    Dispatchers.setMain(Dispatchers.Unconfined)
+    MockitoAnnotations.openMocks(this)
+  }
+
+  @OptIn(ExperimentalCoroutinesApi::class)
+  @After
+  fun cleanUp() {
+    Dispatchers.resetMain()
+  }
+
+  @Test
+  fun underThresholdsIsCalledIfTextIsUnderThresholds() {
+    whenever(textModerationRepository.evaluateText(any(), any())).thenReturn(true)
+
+    val underThresholdsCallback = mock<() -> Unit>()
+    textModerationViewModel.analyzeText("content", { underThresholdsCallback.invoke() }, {})
+    verify(underThresholdsCallback).invoke()
+  }
+
+  @Test
+  fun overThresholdsIsCalledIfTextIsOverThresholds() {
+    whenever(textModerationRepository.evaluateText(any(), any())).thenReturn(false)
+
+    val overThresholdsCallback = mock<() -> Unit>()
+    textModerationViewModel.analyzeText("content", {}, { overThresholdsCallback() })
+    verify(overThresholdsCallback).invoke()
+  }
+}

--- a/app/src/test/java/com/android/streetworkapp/model/textmoderation/TextModerationViewModelTest.kt
+++ b/app/src/test/java/com/android/streetworkapp/model/textmoderation/TextModerationViewModelTest.kt
@@ -1,5 +1,6 @@
 package com.android.streetworkapp.model.textmoderation
 
+import com.android.streetworkapp.model.moderation.TextEvaluation
 import com.android.streetworkapp.model.moderation.TextModerationRepository
 import com.android.streetworkapp.model.moderation.TextModerationViewModel
 import kotlinx.coroutines.Dispatchers
@@ -37,19 +38,21 @@ class TextModerationViewModelTest {
 
   @Test
   fun underThresholdsIsCalledIfTextIsUnderThresholds() {
-    whenever(textModerationRepository.evaluateText(any(), any())).thenReturn(true)
+    whenever(textModerationRepository.evaluateText(any(), any()))
+        .thenReturn(TextEvaluation.Result(true))
 
-    val underThresholdsCallback = mock<() -> Unit>()
-    textModerationViewModel.analyzeText("content", { underThresholdsCallback.invoke() }, {})
-    verify(underThresholdsCallback).invoke()
+    val onEvaluationResultCallback = mock<(Boolean) -> Unit>()
+    textModerationViewModel.analyzeText("content", { onEvaluationResultCallback(it) }, {})
+    verify(onEvaluationResultCallback).invoke(true)
   }
 
   @Test
   fun overThresholdsIsCalledIfTextIsOverThresholds() {
-    whenever(textModerationRepository.evaluateText(any(), any())).thenReturn(false)
+    whenever(textModerationRepository.evaluateText(any(), any()))
+        .thenReturn(TextEvaluation.Result(false))
 
-    val overThresholdsCallback = mock<() -> Unit>()
-    textModerationViewModel.analyzeText("content", {}, { overThresholdsCallback() })
-    verify(overThresholdsCallback).invoke()
+    val onEvaluationResultCallback = mock<(Boolean) -> Unit>()
+    textModerationViewModel.analyzeText("content", { onEvaluationResultCallback(it) }, {})
+    verify(onEvaluationResultCallback).invoke(false)
   }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -47,6 +47,9 @@ playServicesMaps = "19.0.0"
 mapsCompose = "4.3.3"
 mapsComposeUtils = "4.3.0"
 
+#Serialization
+kotlinxSerializationJson = "1.6.0"
+
 # Test Libraries
 mockk = "1.13.7"
 mockkAgent = "1.13.7"
@@ -69,6 +72,7 @@ junit = { group = "junit", name = "junit", version.ref = "junit" }
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }
 androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espressoCore" }
 androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "appcompat" }
+kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinxSerializationJson" }
 material = { group = "com.google.android.material", name = "material", version.ref = "material" }
 androidx-lifecycle-runtime-ktx = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "lifecycleRuntimeKtx" }
 
@@ -122,6 +126,8 @@ androidx-navigation-runtime-ktx = { group = "androidx.navigation", name = "navig
 androidx-navigation-compose = { group = "androidx.navigation", name = "navigation-compose", version.ref = "navigationCompose" }
 androidx-navigation-testing = { group = "androidx.navigation", name = "navigation-testing", version.ref = "navigationTesting" }
 androidx-runtime-livedata = { group = "androidx.compose.runtime", name = "runtime-livedata", version.ref = "runtimeLivedata" }
+
+
 
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
This pr aims to implement a text moderation system for our app.

The current flow works like this:
I have a text to be analyzed called `content`, I call `TextModerationViewModel::analyzeText` with `content`. I can select 2 functions as callbacks: one if the the text is under the thresholds (considered clean), another one if the text is over the thresholds. I can either provide the threshold values by myself or use the default ones.

**Note:** I haven't tinkered too much around the default threshold values. . I put the values quite low at 0.2 (Probability of text being of tag 'x') since the only use cases are for event names and event descriptions (and those texts should be non-ambiguous).
The system is far from perfect. If I have some long inputs with a few words of hate speech only at the end, this won't get picked up.



- **`libs.version.toml.kt` & `build.gradle.kts`**
  - Add BuildConfig to be able to retrieve the Perspective API key from local.properties
  - Add dependency for kotlinxSerializationJson that let's us easily serialize/deserialize api requests/responses

- **`TextModerationRepository.kt`**
  - Interface for our TextModeration repository

- **`PerspectiveAPIModels.kt`**
  - Contains all the data structures needed to interact with the API as well as some custom types for return values and tags

- **`PerspectiveAPIRepository.kt`**
  - Wrapper for the Perspective API. Handles all requests to the api

- **`TextModerationViewModel.kt`**
  - ViewModel for our TextModeration repository

- **`PerspectiveAPIRepositoryTest.kt` & `TextModerationViewModelTest.tk`**
  - Tests for the repository and viewmodel respectively

**Note:** It is not implemented in the UI, this is for another pr

**Update:** There is a rate limit of 1 RPS for the API. If we plan to release app, i'll have to take this into account, for now this is unhandled.


