### PR TITLE
Feat/Get and set current user

### DIFF
--- a/app/src/main/java/com/android/streetworkapp/model/user/UserRepository.kt
+++ b/app/src/main/java/com/android/streetworkapp/model/user/UserRepository.kt
@@ -6,6 +6,8 @@ interface UserRepository {
 
   suspend fun getUserByUid(uid: String): User?
 
+  suspend fun getUserByUidAndSetAsCurrentUser(uid: String): User?
+
   suspend fun getUserByEmail(email: String): User?
 
   suspend fun getUserByUserName(userName: String): User?

--- a/app/src/main/java/com/android/streetworkapp/model/user/UserRepository.kt
+++ b/app/src/main/java/com/android/streetworkapp/model/user/UserRepository.kt
@@ -6,8 +6,6 @@ interface UserRepository {
 
   suspend fun getUserByUid(uid: String): User?
 
-  suspend fun getUserByUidAndSetAsCurrentUser(uid: String): User?
-
   suspend fun getUserByEmail(email: String): User?
 
   suspend fun getUserByUserName(userName: String): User?

--- a/app/src/main/java/com/android/streetworkapp/model/user/UserViewModel.kt
+++ b/app/src/main/java/com/android/streetworkapp/model/user/UserViewModel.kt
@@ -82,6 +82,21 @@ open class UserViewModel(private val repository: UserRepository) : ViewModel() {
   }
 
   /**
+   * Retrieves a user from Firestore based on the provided uid and set it as the current user.
+   *
+   * @param uid The unique ID of the user to retrieve.
+   * @return The User object if found, or null if the user doesn't exist or an error occurs.
+   */
+  fun getUserByUidAndSetAsCurrentUser(uid: String) {
+    viewModelScope.launch {
+      val user = repository.getUserByUid(uid)
+      if (user != null) {
+        _currentUser.value = user
+      }
+    }
+  }
+
+  /**
    * Retrieves a user from Firestore based on the provided email.
    *
    * @param email The email of the user to retrieve.

--- a/app/src/test/java/com/android/streetworkapp/model/user/UserViewModelTest.kt
+++ b/app/src/test/java/com/android/streetworkapp/model/user/UserViewModelTest.kt
@@ -55,6 +55,27 @@ class UserViewModelTest {
   }
 
   @Test
+  fun getUserByUidAndSetAsCurrentUserCallsRepositoryWithCorrectUid() = runTest {
+    val uid = "user123"
+    val user = User(uid, "John Doe", "john@example.com", 100, emptyList(), picture = "")
+    whenever(repository.getUserByUid(uid)).thenReturn(user)
+    userViewModel.getUserByUidAndSetAsCurrentUser(uid)
+    testDispatcher.scheduler.advanceUntilIdle()
+    verify(repository).getUserByUid(uid)
+  }
+
+  @Test
+  fun getUserByUidAndSetAsCurrentUserUpdatesCurrentUser() = runTest {
+    val uid = "user123"
+    val user = User(uid, "John Doe", "john@example.com", 100, emptyList(), picture = "")
+    whenever(repository.getUserByUid(uid)).thenReturn(user)
+    userViewModel.getUserByUidAndSetAsCurrentUser(uid)
+    testDispatcher.scheduler.advanceUntilIdle()
+    val observedUser = userViewModel.currentUser.first()
+    assertEquals(user, observedUser)
+  }
+
+  @Test
   fun getUserByEmailCallsRepositoryWithCorrectEmail() = runTest {
     val email = "john@example.com"
     val user = User("user123", "John Doe", email, 100, emptyList(), picture = "")


### PR DESCRIPTION
### Summary 

The purpose of this short PR is to implement a new function in the User ViewModel that gets a user by user id and sets it as the current user, enabling this operation to be performed in a single line and thus avoiding synchronous problems when this task was performed in two operations. 

### Changes 

- Add the `getUserByUidAndSetAsCurrentUser` in `UserViewModel.kt`

### Testing

- Implement tests to test `getUserByUidAndSetAsCurrentUser` in `UserViewModelTest.kt`