### PR TITLE
Change maps markers colors to be coherent with the rest of the UI

### DIFF
--- a/app/src/main/java/com/android/streetworkapp/ui/map/MapUi.kt
+++ b/app/src/main/java/com/android/streetworkapp/ui/map/MapUi.kt
@@ -22,6 +22,7 @@ import com.android.streetworkapp.ui.navigation.NavigationActions
 import com.android.streetworkapp.ui.navigation.Screen
 import com.android.streetworkapp.utils.LocationService
 import com.android.streetworkapp.utils.PermissionManager
+import com.google.android.gms.maps.model.BitmapDescriptorFactory
 import com.google.android.gms.maps.model.CameraPosition
 import com.google.android.gms.maps.model.LatLng
 import com.google.maps.android.compose.GoogleMap
@@ -96,6 +97,7 @@ fun MapScreen(
             Marker(
                 contentDescription = "Marker$markerIndex",
                 state = MarkerState(position = LatLng(park.lat, park.lon)),
+                icon = BitmapDescriptorFactory.defaultMarker(BitmapDescriptorFactory.HUE_AZURE),
                 onClick = {
                   parkViewModel.getOrCreateParkByLocation(park)
                   parkViewModel.setParkLocation(park)


### PR DESCRIPTION
## Overview
The objective of this Pull Request is to change the default markers we currently have in the map, in order to obtain a more coherent UI in the app.

(Note: This Pull Request was originally supposed to implement more meaningful feature to the map, but I blocked and I could not finish it. To make sure that we have a coherent UI for the next demo, I propose the current Pull Request instead.)

## Changes

- The color of the markers are now coherent with the rest of the app.

## How to test
Once you go to the map screen, the markers should now appear as blue.


## Screenshot

<img width="227" alt="image" src="https://github.com/user-attachments/assets/f77245a2-d00d-4166-9076-9cb5ebe0b766">




