### PR TITLE
Feat/Preferences MVVM

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -251,6 +251,10 @@ dependencies {
     androidTestImplementation(libs.mockito.kotlin)
     androidTestImplementation (libs.mockito.android)
 
+    // Preferences DataStore
+    implementation(libs.datastore.preferences)
+    implementation(libs.datastore.core)
+
 }
 
 configurations.configureEach {

--- a/app/src/main/java/com/android/streetworkapp/device/datastore/DataStoreManager.kt
+++ b/app/src/main/java/com/android/streetworkapp/device/datastore/DataStoreManager.kt
@@ -4,16 +4,36 @@ import android.content.Context
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
 
 class DataStoreManager(context: Context) {
 
-  private val Context.dataStore: DataStore<Preferences> by preferencesDataStore(name = "settings")
+  private val Context.dataStore: DataStore<Preferences> by
+      preferencesDataStore(name = "preferences")
   private val dataStore = context.dataStore
 
   companion object {
     val IS_LOGGED_IN = booleanPreferencesKey("is_logged_in")
     val SAVED_UID = stringPreferencesKey("saved_uid")
+  }
+
+  /**
+   * Saves the login state of the user in preferences.
+   *
+   * @param isLoggedIn: The boolean login state of the user
+   */
+  suspend fun saveLoginState(isLoggedIn: Boolean) {
+    dataStore.edit { preferences -> preferences[IS_LOGGED_IN] = isLoggedIn }
+  }
+
+  /**
+   * Saves the user's uid in preferences.
+   *
+   * @param uid: The user's uid
+   */
+  suspend fun saveUid(uid: String) {
+    dataStore.edit { preferences -> preferences[SAVED_UID] = uid }
   }
 }

--- a/app/src/main/java/com/android/streetworkapp/device/datastore/DataStoreManager.kt
+++ b/app/src/main/java/com/android/streetworkapp/device/datastore/DataStoreManager.kt
@@ -23,6 +23,7 @@ class DataStoreManager(context: Context) {
   companion object {
     val IS_LOGGED_IN = booleanPreferencesKey("is_logged_in")
     val SAVED_UID = stringPreferencesKey("saved_uid")
+    val SAVED_NAME = stringPreferencesKey("saved_name")
   }
 
   /** A flow that emits the login state of the user. */
@@ -53,6 +54,20 @@ class DataStoreManager(context: Context) {
           }
           .map { preferences -> preferences[SAVED_UID] ?: "" }
 
+  /** A flow that emits the user's name. */
+  val savedNameFlow: Flow<String> =
+      dataStore.data
+          .catch { exception ->
+            // Handle exceptions
+            if (exception is IOException) {
+              emit(emptyPreferences())
+              Log.d("DataStoreManager", "An IO exception occurred, emitting empty preferences.")
+            } else {
+              Log.d("DataStoreManager", exception.message.toString())
+            }
+          }
+          .map { preferences -> preferences[SAVED_NAME] ?: "" }
+
   /**
    * Saves the login state of the user in preferences.
    *
@@ -69,5 +84,14 @@ class DataStoreManager(context: Context) {
    */
   suspend fun saveUid(uid: String) {
     dataStore.edit { preferences -> preferences[SAVED_UID] = uid }
+  }
+
+  /**
+   * Saves the user's name in preferences.
+   *
+   * @param name: The user's name
+   */
+  suspend fun saveName(name: String) {
+    dataStore.edit { preferences -> preferences[SAVED_NAME] = name }
   }
 }

--- a/app/src/main/java/com/android/streetworkapp/device/datastore/DataStoreManager.kt
+++ b/app/src/main/java/com/android/streetworkapp/device/datastore/DataStoreManager.kt
@@ -7,6 +7,7 @@ import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.emptyPreferences
+import androidx.datastore.preferences.core.intPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
 import java.io.IOException
@@ -24,6 +25,7 @@ class DataStoreManager(context: Context) {
     val IS_LOGGED_IN = booleanPreferencesKey("is_logged_in")
     val SAVED_UID = stringPreferencesKey("saved_uid")
     val SAVED_NAME = stringPreferencesKey("saved_name")
+    val SAVED_SCORE = intPreferencesKey("saved_score")
   }
 
   /** A flow that emits the login state of the user. */
@@ -68,6 +70,20 @@ class DataStoreManager(context: Context) {
           }
           .map { preferences -> preferences[SAVED_NAME] ?: "" }
 
+  /** A flow that emits the user's score. */
+  val savedScoreFlow: Flow<Int> =
+      dataStore.data
+          .catch { exception ->
+            // Handle exceptions
+            if (exception is IOException) {
+              emit(emptyPreferences())
+              Log.d("DataStoreManager", "An IO exception occurred, emitting empty preferences.")
+            } else {
+              Log.d("DataStoreManager", exception.message.toString())
+            }
+          }
+          .map { preferences -> preferences[SAVED_SCORE] ?: 0 }
+
   /**
    * Saves the login state of the user in preferences.
    *
@@ -93,5 +109,14 @@ class DataStoreManager(context: Context) {
    */
   suspend fun saveName(name: String) {
     dataStore.edit { preferences -> preferences[SAVED_NAME] = name }
+  }
+
+  /**
+   * Saves the user's score in preferences.
+   *
+   * @param score: The user's score
+   */
+  suspend fun saveScore(score: Int) {
+    dataStore.edit { preferences -> preferences[SAVED_SCORE] = score }
   }
 }

--- a/app/src/main/java/com/android/streetworkapp/device/datastore/DataStoreManager.kt
+++ b/app/src/main/java/com/android/streetworkapp/device/datastore/DataStoreManager.kt
@@ -1,12 +1,18 @@
 package com.android.streetworkapp.device.datastore
 
 import android.content.Context
+import android.util.Log
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.emptyPreferences
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
+import java.io.IOException
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.map
 
 class DataStoreManager(context: Context) {
 
@@ -18,6 +24,34 @@ class DataStoreManager(context: Context) {
     val IS_LOGGED_IN = booleanPreferencesKey("is_logged_in")
     val SAVED_UID = stringPreferencesKey("saved_uid")
   }
+
+  /** A flow that emits the login state of the user. */
+  val isLoggedInFlow: Flow<Boolean> =
+      dataStore.data
+          .catch { exception ->
+            // Handle exceptions
+            if (exception is IOException) {
+              emit(emptyPreferences())
+              Log.d("DataStoreManager", "An IO exception occurred, emitting empty preferences.")
+            } else {
+              Log.d("DataStoreManager", exception.message.toString())
+            }
+          }
+          .map { preferences -> preferences[IS_LOGGED_IN] ?: false }
+
+  /** A flow that emits the user's uid. */
+  val savedUidFlow: Flow<String> =
+      dataStore.data
+          .catch { exception ->
+            // Handle exceptions
+            if (exception is IOException) {
+              emit(emptyPreferences())
+              Log.d("DataStoreManager", "An IO exception occurred, emitting empty preferences.")
+            } else {
+              Log.d("DataStoreManager", exception.message.toString())
+            }
+          }
+          .map { preferences -> preferences[SAVED_UID] ?: "" }
 
   /**
    * Saves the login state of the user in preferences.

--- a/app/src/main/java/com/android/streetworkapp/device/datastore/DataStoreManager.kt
+++ b/app/src/main/java/com/android/streetworkapp/device/datastore/DataStoreManager.kt
@@ -1,3 +1,19 @@
 package com.android.streetworkapp.device.datastore
 
-class DataStoreManager {}
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+
+class DataStoreManager(context: Context) {
+
+  private val Context.dataStore: DataStore<Preferences> by preferencesDataStore(name = "settings")
+  private val dataStore = context.dataStore
+
+  companion object {
+    val IS_LOGGED_IN = booleanPreferencesKey("is_logged_in")
+    val SAVED_UID = stringPreferencesKey("saved_uid")
+  }
+}

--- a/app/src/main/java/com/android/streetworkapp/device/datastore/DataStoreManager.kt
+++ b/app/src/main/java/com/android/streetworkapp/device/datastore/DataStoreManager.kt
@@ -1,0 +1,3 @@
+package com.android.streetworkapp.device.datastore
+
+class DataStoreManager {}

--- a/app/src/main/java/com/android/streetworkapp/model/preferences/PreferencesRepository.kt
+++ b/app/src/main/java/com/android/streetworkapp/model/preferences/PreferencesRepository.kt
@@ -1,0 +1,60 @@
+package com.android.streetworkapp.model.preferences
+
+/** A repository interface for preferences data. */
+interface PreferencesRepository {
+  /**
+   * Returns the login state of the user.
+   *
+   * @return True if the user is logged in, false otherwise
+   */
+  suspend fun getLoginState(): Boolean
+
+  /**
+   * Sets the login state of the user.
+   *
+   * @param isLoggedIn True if the user is logged in, false otherwise
+   */
+  suspend fun setIsLoginState(isLoggedIn: Boolean)
+
+  /**
+   * Returns the user's uid.
+   *
+   * @return The user's uid
+   */
+  suspend fun getUid(): String
+
+  /**
+   * Sets the user's uid.
+   *
+   * @param savedUid The user's uid
+   */
+  suspend fun setUid(savedUid: String)
+
+  /**
+   * Returns the user's name.
+   *
+   * @return The user's name
+   */
+  suspend fun getName(): String
+
+  /**
+   * Sets the user's name.
+   *
+   * @param savedName The user's name
+   */
+  suspend fun setName(savedName: String)
+
+  /**
+   * Returns the user's score.
+   *
+   * @return The user's score
+   */
+  suspend fun getScore(): Int
+
+  /**
+   * Sets the user's score.
+   *
+   * @param savedScore The user's score
+   */
+  suspend fun setScore(savedScore: Int)
+}

--- a/app/src/main/java/com/android/streetworkapp/model/preferences/PreferencesRepository.kt
+++ b/app/src/main/java/com/android/streetworkapp/model/preferences/PreferencesRepository.kt
@@ -12,9 +12,9 @@ interface PreferencesRepository {
   /**
    * Sets the login state of the user.
    *
-   * @param isLoggedIn True if the user is logged in, false otherwise
+   * @param loginState True if the user is logged in, false otherwise
    */
-  suspend fun setIsLoginState(isLoggedIn: Boolean)
+  suspend fun setLoginState(loginState: Boolean)
 
   /**
    * Returns the user's uid.
@@ -26,9 +26,9 @@ interface PreferencesRepository {
   /**
    * Sets the user's uid.
    *
-   * @param savedUid The user's uid
+   * @param uid The user's uid
    */
-  suspend fun setUid(savedUid: String)
+  suspend fun setUid(uid: String)
 
   /**
    * Returns the user's name.
@@ -40,9 +40,9 @@ interface PreferencesRepository {
   /**
    * Sets the user's name.
    *
-   * @param savedName The user's name
+   * @param name The user's name
    */
-  suspend fun setName(savedName: String)
+  suspend fun setName(name: String)
 
   /**
    * Returns the user's score.
@@ -54,7 +54,7 @@ interface PreferencesRepository {
   /**
    * Sets the user's score.
    *
-   * @param savedScore The user's score
+   * @param score The user's score
    */
-  suspend fun setScore(savedScore: Int)
+  suspend fun setScore(score: Int)
 }

--- a/app/src/main/java/com/android/streetworkapp/model/preferences/PreferencesRepositoryDataStore.kt
+++ b/app/src/main/java/com/android/streetworkapp/model/preferences/PreferencesRepositoryDataStore.kt
@@ -30,7 +30,7 @@ class PreferencesRepositoryDataStore(context: Context) : PreferencesRepository {
   }
 
   /** A flow that emits the login state of the user. */
-  val isLoggedInFlow: Flow<Boolean> =
+  val loginStateFlow: Flow<Boolean> =
       dataStore.data
           .catch { exception ->
             // Handle exceptions
@@ -44,7 +44,7 @@ class PreferencesRepositoryDataStore(context: Context) : PreferencesRepository {
           .map { preferences -> preferences[IS_LOGGED_IN] ?: false }
 
   /** A flow that emits the user's uid. */
-  val savedUidFlow: Flow<String> =
+  val uidFlow: Flow<String> =
       dataStore.data
           .catch { exception ->
             // Handle exceptions
@@ -58,7 +58,7 @@ class PreferencesRepositoryDataStore(context: Context) : PreferencesRepository {
           .map { preferences -> preferences[SAVED_UID] ?: "" }
 
   /** A flow that emits the user's name. */
-  val savedNameFlow: Flow<String> =
+  val nameFlow: Flow<String> =
       dataStore.data
           .catch { exception ->
             // Handle exceptions
@@ -72,7 +72,7 @@ class PreferencesRepositoryDataStore(context: Context) : PreferencesRepository {
           .map { preferences -> preferences[SAVED_NAME] ?: "" }
 
   /** A flow that emits the user's score. */
-  val savedScoreFlow: Flow<Int> =
+  val scoreFlow: Flow<Int> =
       dataStore.data
           .catch { exception ->
             // Handle exceptions
@@ -91,7 +91,7 @@ class PreferencesRepositoryDataStore(context: Context) : PreferencesRepository {
    * @return The boolean login state of the user
    */
   override suspend fun getLoginState(): Boolean {
-    return isLoggedInFlow.firstOrNull() ?: false
+    return loginStateFlow.firstOrNull() ?: false
   }
 
   /**
@@ -109,7 +109,7 @@ class PreferencesRepositoryDataStore(context: Context) : PreferencesRepository {
    * @return The user's uid
    */
   override suspend fun getUid(): String {
-    return savedUidFlow.firstOrNull() ?: ""
+    return uidFlow.firstOrNull() ?: ""
   }
 
   /**
@@ -127,7 +127,7 @@ class PreferencesRepositoryDataStore(context: Context) : PreferencesRepository {
    * @return The user's name
    */
   override suspend fun getName(): String {
-    return savedNameFlow.firstOrNull() ?: ""
+    return nameFlow.firstOrNull() ?: ""
   }
 
   /**
@@ -145,7 +145,7 @@ class PreferencesRepositoryDataStore(context: Context) : PreferencesRepository {
    * @return The user's score
    */
   override suspend fun getScore(): Int {
-    return savedScoreFlow.firstOrNull() ?: 0
+    return scoreFlow.firstOrNull() ?: 0
   }
 
   /**

--- a/app/src/main/java/com/android/streetworkapp/model/preferences/PreferencesRepositoryDataStore.kt
+++ b/app/src/main/java/com/android/streetworkapp/model/preferences/PreferencesRepositoryDataStore.kt
@@ -99,7 +99,7 @@ class PreferencesRepositoryDataStore(context: Context) : PreferencesRepository {
   /**
    * Saves the login state of the user in preferences.
    *
-   * @param isLoggedIn: The boolean login state of the user
+   * @param loginState: The boolean login state of the user
    */
   override suspend fun setLoginState(loginState: Boolean) {
     dataStore.edit { preferences -> preferences[IS_LOGGED_IN] = loginState }

--- a/app/src/main/java/com/android/streetworkapp/model/preferences/PreferencesRepositoryDataStore.kt
+++ b/app/src/main/java/com/android/streetworkapp/model/preferences/PreferencesRepositoryDataStore.kt
@@ -81,7 +81,7 @@ class PreferencesRepositoryDataStore(context: Context) : PreferencesRepository {
             // Handle exceptions
             if (exception is IOException) {
               emit(emptyPreferences())
-              Log.d(ERR_TAG, "An IO exception occurred, emitting empty preferences.")
+              Log.d(ERR_TAG, IO_ERR)
             } else {
               Log.d(ERR_TAG, exception.message.toString())
             }

--- a/app/src/main/java/com/android/streetworkapp/model/preferences/PreferencesRepositoryDataStore.kt
+++ b/app/src/main/java/com/android/streetworkapp/model/preferences/PreferencesRepositoryDataStore.kt
@@ -29,6 +29,7 @@ class PreferencesRepositoryDataStore(context: Context) : PreferencesRepository {
     val SAVED_SCORE = intPreferencesKey("saved_score")
 
     private const val IO_ERR = "An IO exception occurred, emitting empty preferences."
+    private const val ERR_TAG = "PreferencesRepositoryDataStore"
   }
 
   /** A flow that emits the login state of the user. */
@@ -38,9 +39,9 @@ class PreferencesRepositoryDataStore(context: Context) : PreferencesRepository {
             // Handle exceptions
             if (exception is IOException) {
               emit(emptyPreferences())
-              Log.d("DataStoreManager", IO_ERR)
+              Log.d(ERR_TAG, IO_ERR)
             } else {
-              Log.d("DataStoreManager", exception.message.toString())
+              Log.d(ERR_TAG, exception.message.toString())
             }
           }
           .map { preferences -> preferences[IS_LOGGED_IN] ?: false }
@@ -52,9 +53,9 @@ class PreferencesRepositoryDataStore(context: Context) : PreferencesRepository {
             // Handle exceptions
             if (exception is IOException) {
               emit(emptyPreferences())
-              Log.d("DataStoreManager", IO_ERR)
+              Log.d(ERR_TAG, IO_ERR)
             } else {
-              Log.d("DataStoreManager", exception.message.toString())
+              Log.d(ERR_TAG, exception.message.toString())
             }
           }
           .map { preferences -> preferences[SAVED_UID] ?: "" }
@@ -66,9 +67,9 @@ class PreferencesRepositoryDataStore(context: Context) : PreferencesRepository {
             // Handle exceptions
             if (exception is IOException) {
               emit(emptyPreferences())
-              Log.d("DataStoreManager", IO_ERR)
+              Log.d(ERR_TAG, IO_ERR)
             } else {
-              Log.d("DataStoreManager", exception.message.toString())
+              Log.d(ERR_TAG, exception.message.toString())
             }
           }
           .map { preferences -> preferences[SAVED_NAME] ?: "" }
@@ -80,9 +81,9 @@ class PreferencesRepositoryDataStore(context: Context) : PreferencesRepository {
             // Handle exceptions
             if (exception is IOException) {
               emit(emptyPreferences())
-              Log.d("DataStoreManager", "An IO exception occurred, emitting empty preferences.")
+              Log.d(ERR_TAG, "An IO exception occurred, emitting empty preferences.")
             } else {
-              Log.d("DataStoreManager", exception.message.toString())
+              Log.d(ERR_TAG, exception.message.toString())
             }
           }
           .map { preferences -> preferences[SAVED_SCORE] ?: 0 }

--- a/app/src/main/java/com/android/streetworkapp/model/preferences/PreferencesRepositoryDataStore.kt
+++ b/app/src/main/java/com/android/streetworkapp/model/preferences/PreferencesRepositoryDataStore.kt
@@ -27,6 +27,8 @@ class PreferencesRepositoryDataStore(context: Context) : PreferencesRepository {
     val SAVED_UID = stringPreferencesKey("saved_uid")
     val SAVED_NAME = stringPreferencesKey("saved_name")
     val SAVED_SCORE = intPreferencesKey("saved_score")
+
+    private const val IO_ERR = "An IO exception occurred, emitting empty preferences."
   }
 
   /** A flow that emits the login state of the user. */
@@ -36,7 +38,7 @@ class PreferencesRepositoryDataStore(context: Context) : PreferencesRepository {
             // Handle exceptions
             if (exception is IOException) {
               emit(emptyPreferences())
-              Log.d("DataStoreManager", "An IO exception occurred, emitting empty preferences.")
+              Log.d("DataStoreManager", IO_ERR)
             } else {
               Log.d("DataStoreManager", exception.message.toString())
             }
@@ -50,7 +52,7 @@ class PreferencesRepositoryDataStore(context: Context) : PreferencesRepository {
             // Handle exceptions
             if (exception is IOException) {
               emit(emptyPreferences())
-              Log.d("DataStoreManager", "An IO exception occurred, emitting empty preferences.")
+              Log.d("DataStoreManager", IO_ERR)
             } else {
               Log.d("DataStoreManager", exception.message.toString())
             }
@@ -64,7 +66,7 @@ class PreferencesRepositoryDataStore(context: Context) : PreferencesRepository {
             // Handle exceptions
             if (exception is IOException) {
               emit(emptyPreferences())
-              Log.d("DataStoreManager", "An IO exception occurred, emitting empty preferences.")
+              Log.d("DataStoreManager", IO_ERR)
             } else {
               Log.d("DataStoreManager", exception.message.toString())
             }

--- a/app/src/main/java/com/android/streetworkapp/model/preferences/PreferencesRepositoryDataStore.kt
+++ b/app/src/main/java/com/android/streetworkapp/model/preferences/PreferencesRepositoryDataStore.kt
@@ -1,4 +1,4 @@
-package com.android.streetworkapp.device.datastore
+package com.android.streetworkapp.model.preferences
 
 import android.content.Context
 import android.util.Log
@@ -15,7 +15,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.map
 
-class DataStoreManager(context: Context) {
+class PreferencesRepositoryDataStore(context: Context) {
 
   private val Context.dataStore: DataStore<Preferences> by
       preferencesDataStore(name = "preferences")

--- a/app/src/main/java/com/android/streetworkapp/model/preferences/PreferencesRepositoryDataStore.kt
+++ b/app/src/main/java/com/android/streetworkapp/model/preferences/PreferencesRepositoryDataStore.kt
@@ -13,9 +13,10 @@ import androidx.datastore.preferences.preferencesDataStore
 import java.io.IOException
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.map
 
-class PreferencesRepositoryDataStore(context: Context) {
+class PreferencesRepositoryDataStore(context: Context) : PreferencesRepository {
 
   private val Context.dataStore: DataStore<Preferences> by
       preferencesDataStore(name = "preferences")
@@ -85,12 +86,30 @@ class PreferencesRepositoryDataStore(context: Context) {
           .map { preferences -> preferences[SAVED_SCORE] ?: 0 }
 
   /**
+   * Returns the login state of the user from preferences.
+   *
+   * @return The boolean login state of the user
+   */
+  override suspend fun getLoginState(): Boolean {
+    return isLoggedInFlow.firstOrNull() ?: false
+  }
+
+  /**
    * Saves the login state of the user in preferences.
    *
    * @param isLoggedIn: The boolean login state of the user
    */
-  suspend fun saveLoginState(isLoggedIn: Boolean) {
-    dataStore.edit { preferences -> preferences[IS_LOGGED_IN] = isLoggedIn }
+  override suspend fun setLoginState(loginState: Boolean) {
+    dataStore.edit { preferences -> preferences[IS_LOGGED_IN] = loginState }
+  }
+
+  /**
+   * Returns the user's uid from preferences.
+   *
+   * @return The user's uid
+   */
+  override suspend fun getUid(): String {
+    return savedUidFlow.firstOrNull() ?: ""
   }
 
   /**
@@ -98,8 +117,17 @@ class PreferencesRepositoryDataStore(context: Context) {
    *
    * @param uid: The user's uid
    */
-  suspend fun saveUid(uid: String) {
+  override suspend fun setUid(uid: String) {
     dataStore.edit { preferences -> preferences[SAVED_UID] = uid }
+  }
+
+  /**
+   * Returns the user's name from preferences.
+   *
+   * @return The user's name
+   */
+  override suspend fun getName(): String {
+    return savedNameFlow.firstOrNull() ?: ""
   }
 
   /**
@@ -107,8 +135,17 @@ class PreferencesRepositoryDataStore(context: Context) {
    *
    * @param name: The user's name
    */
-  suspend fun saveName(name: String) {
+  override suspend fun setName(name: String) {
     dataStore.edit { preferences -> preferences[SAVED_NAME] = name }
+  }
+
+  /**
+   * Returns the user's score from preferences.
+   *
+   * @return The user's score
+   */
+  override suspend fun getScore(): Int {
+    return savedScoreFlow.firstOrNull() ?: 0
   }
 
   /**
@@ -116,7 +153,7 @@ class PreferencesRepositoryDataStore(context: Context) {
    *
    * @param score: The user's score
    */
-  suspend fun saveScore(score: Int) {
+  override suspend fun setScore(score: Int) {
     dataStore.edit { preferences -> preferences[SAVED_SCORE] = score }
   }
 }

--- a/app/src/main/java/com/android/streetworkapp/model/preferences/PreferencesViewModel.kt
+++ b/app/src/main/java/com/android/streetworkapp/model/preferences/PreferencesViewModel.kt
@@ -1,0 +1,91 @@
+package com.android.streetworkapp.model.preferences
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+
+/**
+ * A ViewModel for preferences data.
+ *
+ * @property preferencesRepository The repository for preferences data
+ */
+class PreferencesViewModel(private val preferencesRepository: PreferencesRepository) : ViewModel() {
+
+  /** A StateFlow of the login state of the user. */
+  private val _loginState = MutableStateFlow<Boolean>(false)
+  val loginState: StateFlow<Boolean>
+    get() = _loginState
+
+  /** A StateFlow of the user's uid. */
+  private val _uid = MutableStateFlow<String>("")
+  val uid: StateFlow<String>
+    get() = _uid
+
+  /** A StateFlow of the user's name. */
+  private val _name = MutableStateFlow<String>("")
+  val name: StateFlow<String>
+    get() = _name
+
+  /** A StateFlow of the user's score. */
+  private val _score = MutableStateFlow<Int>(0)
+  val score: StateFlow<Int>
+    get() = _score
+
+  /** Get the login state of the user. */
+  fun getLoginState() {
+    viewModelScope.launch { preferencesRepository.getLoginState().let { _loginState.value = it } }
+  }
+
+  /** Get the user's uid. */
+  fun getUid() {
+    viewModelScope.launch { preferencesRepository.getUid().let { _uid.value = it } }
+  }
+
+  /** Get the user's name. */
+  fun getName() {
+    viewModelScope.launch { preferencesRepository.getName().let { _name.value = it } }
+  }
+
+  /** Get the user's score. */
+  fun getScore() {
+    viewModelScope.launch { preferencesRepository.getScore().let { _score.value = it } }
+  }
+
+  /**
+   * Set the login state of the user.
+   *
+   * @param isLoggedIn The login state of the user
+   */
+  fun setLoginState(isLoggedIn: Boolean) {
+    viewModelScope.launch { preferencesRepository.setLoginState(isLoggedIn) }
+  }
+
+  /**
+   * Set the user's uid.
+   *
+   * @param uid The user's uid
+   */
+  fun setUid(uid: String) {
+    viewModelScope.launch { preferencesRepository.setUid(uid) }
+  }
+
+  /**
+   * Set the user's name.
+   *
+   * @param name The user's name
+   */
+  fun setName(name: String) {
+    viewModelScope.launch { preferencesRepository.setName(name) }
+  }
+
+  /**
+   * Set the user's score.
+   *
+   * @param score The user's score
+   */
+  fun setScore(score: Int) {
+    viewModelScope.launch { preferencesRepository.setScore(score) }
+  }
+}

--- a/app/src/test/java/com/android/streetworkapp/model/preferences/PreferencesViewModelTest.kt
+++ b/app/src/test/java/com/android/streetworkapp/model/preferences/PreferencesViewModelTest.kt
@@ -1,0 +1,111 @@
+package com.android.streetworkapp.model.preferences
+
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.verify
+import org.mockito.kotlin.whenever
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class PreferencesViewModelTest {
+
+  private lateinit var preferencesRepository: PreferencesRepository
+  private lateinit var preferencesViewModel: PreferencesViewModel
+  private val testDispatcher = StandardTestDispatcher()
+
+  @get:Rule val instantTaskExecutorRule = InstantTaskExecutorRule()
+
+  @Before
+  fun setUp() {
+    Dispatchers.setMain(testDispatcher)
+    preferencesRepository = mock()
+    preferencesViewModel = PreferencesViewModel(preferencesRepository)
+  }
+
+  @After
+  fun tearDown() {
+    Dispatchers.resetMain()
+  }
+
+  @Test
+  fun getLoginStateCallsRepositoryAndUpdatesState() = runTest {
+    whenever(preferencesRepository.getLoginState()).thenReturn(true)
+    preferencesViewModel.getLoginState()
+    testDispatcher.scheduler.advanceUntilIdle()
+    assertEquals(true, preferencesViewModel.loginState.first())
+    verify(preferencesRepository).getLoginState()
+  }
+
+  @Test
+  fun getUidCallsRepositoryAndUpdatesState() = runTest {
+    val uid = "user123"
+    whenever(preferencesRepository.getUid()).thenReturn(uid)
+    preferencesViewModel.getUid()
+    testDispatcher.scheduler.advanceUntilIdle()
+    assertEquals(uid, preferencesViewModel.uid.first())
+    verify(preferencesRepository).getUid()
+  }
+
+  @Test
+  fun getNameCallsRepositoryAndUpdatesState() = runTest {
+    val name = "John Doe"
+    whenever(preferencesRepository.getName()).thenReturn(name)
+    preferencesViewModel.getName()
+    testDispatcher.scheduler.advanceUntilIdle()
+    assertEquals(name, preferencesViewModel.name.first())
+    verify(preferencesRepository).getName()
+  }
+
+  @Test
+  fun getScoreCallsRepositoryAndUpdatesState() = runTest {
+    val score = 100
+    whenever(preferencesRepository.getScore()).thenReturn(score)
+    preferencesViewModel.getScore()
+    testDispatcher.scheduler.advanceUntilIdle()
+    assertEquals(score, preferencesViewModel.score.first())
+    verify(preferencesRepository).getScore()
+  }
+
+  @Test
+  fun setLoginStateCallsRepository() = runTest {
+    val isLoggedIn = true
+    preferencesViewModel.setLoginState(isLoggedIn)
+    testDispatcher.scheduler.advanceUntilIdle()
+    verify(preferencesRepository).setLoginState(isLoggedIn)
+  }
+
+  @Test
+  fun setUidCallsRepository() = runTest {
+    val uid = "user123"
+    preferencesViewModel.setUid(uid)
+    testDispatcher.scheduler.advanceUntilIdle()
+    verify(preferencesRepository).setUid(uid)
+  }
+
+  @Test
+  fun setNameCallsRepository() = runTest {
+    val name = "John Doe"
+    preferencesViewModel.setName(name)
+    testDispatcher.scheduler.advanceUntilIdle()
+    verify(preferencesRepository).setName(name)
+  }
+
+  @Test
+  fun setScoreCallsRepository() = runTest {
+    val score = 100
+    preferencesViewModel.setScore(score)
+    testDispatcher.scheduler.advanceUntilIdle()
+    verify(preferencesRepository).setScore(score)
+  }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -62,6 +62,10 @@ mockitoKotlin = "5.4.0"
 mockitoAndroid = "5.13.0"
 runtimeLivedata = "1.7.5"
 
+# Preferences DataStore
+datastorePreferences = "1.0.0"
+datastoreCore = "1.0.0"
+
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
 androidx-core-testing = { module = "androidx.arch.core:core-testing", version.ref = "coreTesting" }
@@ -127,6 +131,9 @@ androidx-navigation-compose = { group = "androidx.navigation", name = "navigatio
 androidx-navigation-testing = { group = "androidx.navigation", name = "navigation-testing", version.ref = "navigationTesting" }
 androidx-runtime-livedata = { group = "androidx.compose.runtime", name = "runtime-livedata", version.ref = "runtimeLivedata" }
 
+# Preferences DataStore
+datastore-preferences = { module = "androidx.datastore:datastore-preferences", version.ref = "datastorePreferences" }
+datastore-core = { module = "androidx.datastore:datastore-core", version.ref = "datastoreCore" }
 
 
 [plugins]


### PR DESCRIPTION
### Summary

This pull request implement a new Preferences MVVM which will be used to cache preferences between different application uses on a device. It will enable parameter caching which allows to save login infos or users on the device for offline access. The repository implemented is the Preferences DataStore provided by android, which enables data to be stored directly on the device. 

This PR cherry picks commits from the soon to be closed PR #166 due to features separation.

### Changes 

- Implemented `PreferencesRepository` interface.
- Implemented `PreferencesRepositoryDataStore` caching preferences class.
- Implemented `PreferencesViewModel` viewmodel.

### Tests

- Implemented `PreferencesViewModel` tests.

**The low line coverage of this PR (30%) and particularly of `PreferencesRepositoryDataStore.kt` is due to the difficulty of testing Preference DataStore. If the reviewer comes up with a functional solution for testing this class, please let me know.** 