### PR TITLE
Linking infodialogs with strings.xml file to avoid hard-coded strings

### DIFF
--- a/app/src/main/java/com/android/streetworkapp/MainActivity.kt
+++ b/app/src/main/java/com/android/streetworkapp/MainActivity.kt
@@ -18,9 +18,9 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.platform.LocalContext
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavType
-import androidx.compose.ui.platform.LocalContext
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController

--- a/app/src/main/java/com/android/streetworkapp/MainActivity.kt
+++ b/app/src/main/java/com/android/streetworkapp/MainActivity.kt
@@ -20,6 +20,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavType
+import androidx.compose.ui.platform.LocalContext
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
@@ -254,7 +255,7 @@ fun StreetWorkApp(
               }
               navigation(startDestination = Screen.PROGRESSION, route = Route.PROGRESSION) {
                 composable(Screen.PROGRESSION) {
-                  infoManager.Display()
+                  infoManager.Display(LocalContext.current)
                   ProgressScreen(
                       navigationActions, userViewModel, progressionViewModel, innerPadding)
                 }
@@ -264,7 +265,7 @@ fun StreetWorkApp(
                   route = Route.MAP,
               ) {
                 composable(Screen.MAP) {
-                  infoManager.Display()
+                  infoManager.Display(LocalContext.current)
                   MapScreen(
                       parkLocationViewModel,
                       parkViewModel,
@@ -273,12 +274,12 @@ fun StreetWorkApp(
                       innerPadding)
                 }
                 composable(Screen.PARK_OVERVIEW) {
-                  infoManager.Display()
+                  infoManager.Display(LocalContext.current)
                   ParkOverviewScreen(
                       parkViewModel, innerPadding, navigationActions, eventViewModel, userViewModel)
                 }
                 composable(Screen.ADD_EVENT) {
-                  infoManager.Display()
+                  infoManager.Display(LocalContext.current)
                   AddEventScreen(
                       navigationActions,
                       parkViewModel,
@@ -290,7 +291,7 @@ fun StreetWorkApp(
                       innerPadding)
                 }
                 composable(Screen.EVENT_OVERVIEW) {
-                  infoManager.Display()
+                  infoManager.Display(LocalContext.current)
                   EventOverviewScreen(
                       eventViewModel, parkViewModel, userViewModel, navigationActions, innerPadding)
                 }
@@ -303,7 +304,7 @@ fun StreetWorkApp(
               ) {
                 // profile screen + list of friend
                 composable(Screen.PROFILE) {
-                  infoManager.Display()
+                  infoManager.Display(LocalContext.current)
                   ProfileScreen(navigationActions, userViewModel, innerPadding)
                   val showSettingsDialog = remember { mutableStateOf(false) }
 
@@ -322,7 +323,7 @@ fun StreetWorkApp(
                 }
                 // screen for adding friend
                 composable(Screen.ADD_FRIEND) {
-                  infoManager.Display()
+                  infoManager.Display(LocalContext.current)
                   AddFriendScreen(userViewModel, navigationActions, scope, host, innerPadding)
                 }
               }

--- a/app/src/main/java/com/android/streetworkapp/ui/navigation/InfoDialogs.kt
+++ b/app/src/main/java/com/android/streetworkapp/ui/navigation/InfoDialogs.kt
@@ -1,11 +1,13 @@
 package com.android.streetworkapp.ui.navigation
 
+import android.content.Context
 import android.util.Log
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.MutableState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
+import com.android.sample.R
 import com.android.streetworkapp.ui.utils.CustomDialog
 import com.android.streetworkapp.ui.utils.DialogType
 
@@ -24,46 +26,28 @@ class InfoDialogManager(
 ) {
   private val screens = getScreens()
 
-  // TODO: Replace the strings by R.strings and solve its context issue.
   // Mapping Screen to InfoDialog
   private val _infoDialogs: MutableMap<String, InfoDialog> =
       mutableMapOf(
           "default" to defaultInfoDialog(),
-          screens.MAP to
-              InfoDialog(
-                  "Map",
-                  "How does the map work ?",
-                  "This is the map, here you can see each park that is near you. \n\n You can navigate to see more. Click on a park to see its details, such as their events !"),
+          screens.MAP to InfoDialog("Map", R.string.MapInfoTitle, R.string.MapInfoContent),
           screens.PROFILE to
-              InfoDialog(
-                  "Profile",
-                  "What is the Profile ?",
-                  "This is your profile page, you can see your friends and your score. \n\n You can also add friends using the 'Add friend' button and you can also access your settings by clicking the gear icon on the top right."),
+              InfoDialog("Profile", R.string.ProfileInfoTitle, R.string.ProfileInfoContent),
           screens.ADD_FRIEND to
-              InfoDialog(
-                  "AddFriend",
-                  "How do friends work ?",
-                  "This is where you can add a friend. \n\n To add, you need to have a friend nearby and activate bluetooth and location services. \n\n Once you are friends you will be able to do workouts with each other. \n\n Have fun together !"),
+              InfoDialog("AddFriend", R.string.AddFriendInfoTitle, R.string.AddFriendInfoContent),
           screens.PARK_OVERVIEW to
               InfoDialog(
-                  "ParkOverview",
-                  "how do parks work?",
-                  "This is the park overview, here you can see the park's details and the events that are planned in it. \n\n You can create an event or join an already existing one. You can also rate the park !"),
+                  "ParkOverview", R.string.ParkOverviewInfoTitle, R.string.ParkOverviewInfoContent),
           screens.ADD_EVENT to
-              InfoDialog(
-                  "AddEvent",
-                  "How to create an event ?",
-                  "This is your first step towards creating an event ! \n\n You simply have to add a cool title, then, describe your event : What are you going to do there ? \n\n Finally, set the date and time and you are good to go !"),
+              InfoDialog("AddEvent", R.string.AddEventInfoTitle, R.string.AddEventInfoContent),
           screens.EVENT_OVERVIEW to
               InfoDialog(
                   "EventOverview",
-                  "What is the Event Overview ?",
-                  "This is the event overview, here you can access all of the information that you need. \n\n You are free to join the event if you want to participate !"),
+                  R.string.EventOverviewInfoTitle,
+                  R.string.EventOverviewInfoContent),
           screens.PROGRESSION to
               InfoDialog(
-                  "Progression",
-                  "What is the Progression ?",
-                  "This is the progression screen, here you can see your progression and achievements. \n\n There is your record for each exercise in Training, click on it to see more details !")
+                  "Progression", R.string.ProgressionInfoTitle, R.string.ProgressionInfoContent)
 
           // Auth not done because unnecessary
           // Add more if needed
@@ -74,10 +58,7 @@ class InfoDialogManager(
 
   /** Returns the default InfoDialog (for screens that are not supported). */
   fun defaultInfoDialog(): InfoDialog {
-    return InfoDialog(
-        "Default",
-        "Screen not supported yet",
-        "Information about this screen is not available. Please explore to learn more!")
+    return InfoDialog("Default", R.string.DefaultInfoTitle, R.string.DefaultInfoContent)
   }
 
   /**
@@ -98,20 +79,20 @@ class InfoDialogManager(
    * a default "non-supported" version is displayed.
    */
   @Composable
-  fun Display() {
+  fun Display(context: Context) {
     Log.d("InfoDialog", "Displaying info dialog ${showDialog.value} for screen ${screenName.value}")
     val func = _infoDialogs[screenName.value]
     if (func != null) {
       Log.d("InfoDialog", "Displaying info dialog : ${func.title}")
-      func.DisplayInfoDialog(showDialog)
+      func.DisplayInfoDialog(showDialog, context)
     } else {
       Log.d("InfoDialog", "Displaying default info dialog : ${defaultInfoDialog().title}")
-      defaultInfoDialog().DisplayInfoDialog(showDialog)
+      defaultInfoDialog().DisplayInfoDialog(showDialog, context)
     }
   }
 }
 
-class InfoDialog(val tag: String, val title: String, val content: String) {
+class InfoDialog(val tag: String, val title: Int, val content: Int) {
 
   /**
    * This function displays the info dialog, which is a specific Type of CustomDialog.
@@ -119,13 +100,13 @@ class InfoDialog(val tag: String, val title: String, val content: String) {
    * @param showDialog - The display state of the dialog.
    */
   @Composable
-  fun DisplayInfoDialog(showDialog: MutableState<Boolean>) {
+  fun DisplayInfoDialog(showDialog: MutableState<Boolean>, context: Context) {
     CustomDialog(
         showDialog,
         dialogType = DialogType.INFO,
         "${tag}Info",
-        title,
-        Content = { DisplayInfoContent(content) })
+        context.getString(title),
+        Content = { DisplayInfoContent(context.getString(content)) })
   }
 
   /** Function wrapper to allow more customization later on */


### PR DESCRIPTION
## Assistants gave a solution that works 

- Apply R.strings (**Type** `Int` instead of `String`)
- Then, in **@Composable** `display()` functions, use `Context.getString(Int)`

### Some changes in main

I choose to use `LocalContext.current` for each call to the `InfoDialogManager.display()` instead of using one context variable. I did this because the screens are not the same, which implies changes to the scaffold / other elements, which might break the **@Composable** if I use an older context.

### Changing tests

Because the type of the `InfoDialog` changed, needed to re-write some tests which used specific strings.

### There should be no changes feature-wise

<p align="center">
<img src="https://github.com/user-attachments/assets/993848ba-30bc-45e1-b5ff-0c5b387e0940" alt="image" width="346">
</p>