### PR TITLE
Feat/finish implementing the settings for the profile

### DIFF
--- a/app/src/androidTest/java/com/android/streetworkapp/ui/profile/SettingsTest.kt
+++ b/app/src/androidTest/java/com/android/streetworkapp/ui/profile/SettingsTest.kt
@@ -1,0 +1,92 @@
+package com.android.streetworkapp.ui.profile
+
+import android.content.Context
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.test.assertHasClickAction
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsNotDisplayed
+import androidx.compose.ui.test.assertTextEquals
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.android.sample.R
+import com.android.streetworkapp.model.user.User
+import com.android.streetworkapp.model.user.UserRepository
+import com.android.streetworkapp.model.user.UserViewModel
+import com.android.streetworkapp.ui.navigation.NavigationActions
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mockito
+
+@RunWith(AndroidJUnit4::class)
+class SettingsTest {
+
+  @get:Rule val composeTestRule = createComposeRule()
+
+  private val navigationActions = Mockito.mock(NavigationActions::class.java)
+  private val userRepository = Mockito.mock(UserRepository::class.java)
+  private val userViewModel = UserViewModel(userRepository)
+
+  @Test
+  fun isSettingsContentDisplayedForNullUser() {
+    val showSettingDialog = mutableStateOf(false)
+    userViewModel.setCurrentUser(null)
+    var context: Context? = null
+
+    composeTestRule.setContent {
+      SettingsContent(navigationActions, userViewModel, showSettingDialog)
+      context = LocalContext.current
+    }
+
+    composeTestRule.onNodeWithTag("SettingsContent").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("NullUserSettingsContent").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("ConnectionSettingsContent").assertDoesNotExist()
+    composeTestRule.onNodeWithTag("LogOutButton").assertDoesNotExist()
+    composeTestRule.onNodeWithTag("DeleteAccountButton").assertDoesNotExist()
+    composeTestRule.onNodeWithTag("deleteAccountDialog").assertIsNotDisplayed()
+
+    showSettingDialog.value = true
+    composeTestRule.waitForIdle()
+
+    composeTestRule.onNodeWithTag("SettingsContent").assertIsDisplayed()
+    composeTestRule
+        .onNodeWithTag("NullUserSettingsContent")
+        .assertIsDisplayed()
+        .assertTextEquals(context!!.getString(R.string.SettingsNullUserContent))
+    composeTestRule.onNodeWithTag("ConnectionSettingsContent").assertDoesNotExist()
+    composeTestRule.onNodeWithTag("LogOutButton").assertDoesNotExist()
+    composeTestRule.onNodeWithTag("DeleteAccountButton").assertDoesNotExist()
+    composeTestRule.onNodeWithTag("deleteAccountDialog").assertIsNotDisplayed()
+  }
+
+  @Test
+  fun isSettingsContentDisplayedForUser() {
+    val showSettingDialog = mutableStateOf(false)
+    var context: Context? = null
+    val alice = User("uid-alice", "Alice", "alice@gmail.com", 42, emptyList(), "")
+    userViewModel.setCurrentUser(alice)
+
+    composeTestRule.setContent {
+      SettingsContent(navigationActions, userViewModel, showSettingDialog)
+      context = LocalContext.current
+    }
+
+    composeTestRule.onNodeWithTag("SettingsContent").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("NullUserSettingsContent").assertIsNotDisplayed()
+    composeTestRule
+        .onNodeWithTag("ConnectionSettingsContent")
+        .assertIsDisplayed()
+        .assertTextEquals(context!!.getString(R.string.SettingsConnectionContent, alice.username))
+    composeTestRule.onNodeWithTag("LogOutButton").assertIsDisplayed().assertHasClickAction()
+    composeTestRule.onNodeWithTag("DeleteAccountButton").assertIsDisplayed().assertHasClickAction()
+    composeTestRule.onNodeWithTag("deleteAccountDialog").assertIsNotDisplayed()
+
+    composeTestRule.onNodeWithTag("DeleteAccountButton").performClick()
+    composeTestRule.waitForIdle()
+
+    composeTestRule.onNodeWithTag("deleteAccountDialog").assertIsDisplayed()
+  }
+}

--- a/app/src/main/java/com/android/streetworkapp/MainActivity.kt
+++ b/app/src/main/java/com/android/streetworkapp/MainActivity.kt
@@ -12,7 +12,6 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Snackbar
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -63,6 +62,7 @@ import com.android.streetworkapp.ui.navigation.TopAppBarWrapper
 import com.android.streetworkapp.ui.park.ParkOverviewScreen
 import com.android.streetworkapp.ui.profile.AddFriendScreen
 import com.android.streetworkapp.ui.profile.ProfileScreen
+import com.android.streetworkapp.ui.profile.SettingsContent
 import com.android.streetworkapp.ui.progress.ProgressScreen
 import com.android.streetworkapp.ui.theme.ColorPalette
 import com.android.streetworkapp.ui.train.TrainChallengeScreen
@@ -71,6 +71,7 @@ import com.android.streetworkapp.ui.train.TrainHubScreen
 import com.android.streetworkapp.ui.train.TrainSoloScreen
 import com.android.streetworkapp.ui.tutorial.TutorialEvent
 import com.android.streetworkapp.ui.utils.CustomDialog
+import com.android.streetworkapp.ui.utils.DialogType
 import com.google.firebase.firestore.FirebaseFirestore
 import okhttp3.OkHttpClient
 
@@ -318,11 +319,14 @@ fun StreetWorkApp(
                       }
 
                   // The settings "in" the profile screen
-                  // TODO : Implement the dialog Content composable
                   CustomDialog(
                       showSettingsDialog,
+                      dialogType = DialogType.INFO,
                       tag = "Settings",
-                      Content = { Text("Settings to be implemented") },
+                      title = "Settings",
+                      Content = {
+                        SettingsContent(navigationActions, userViewModel, showSettingsDialog)
+                      },
                   )
                 }
                 // screen for adding friend

--- a/app/src/main/java/com/android/streetworkapp/ui/profile/Settings.kt
+++ b/app/src/main/java/com/android/streetworkapp/ui/profile/Settings.kt
@@ -14,6 +14,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import com.android.sample.R
 import com.android.streetworkapp.model.user.UserViewModel
@@ -28,58 +29,61 @@ fun SettingsContent(
     userViewModel: UserViewModel,
     showParentDialog: MutableState<Boolean>
 ) {
-  Column() {
-    val currentUser = remember { userViewModel.currentUser.value }
-    val showConfirmUserDelete = remember { mutableStateOf(false) }
-    val context = LocalContext.current
 
-    Column(
-        modifier = Modifier.fillMaxWidth(),
-        verticalArrangement = Arrangement.spacedBy(4.dp),
-        horizontalAlignment = Alignment.CenterHorizontally) {
+  val currentUser = remember { userViewModel.currentUser.value }
+  val showConfirmUserDelete = remember { mutableStateOf(false) }
+  val context = LocalContext.current
 
-          // Settings content
-          if (currentUser == null) {
-            Text(context.getString(R.string.SettingsNullUserContent))
-          } else {
-            Text(
-                context.getString(R.string.SettingsConnectionContent),
-                modifier = Modifier.padding(bottom = 16.dp))
+  Column(
+      modifier = Modifier.fillMaxWidth().testTag("SettingsContent"),
+      verticalArrangement = Arrangement.spacedBy(4.dp),
+      horizontalAlignment = Alignment.CenterHorizontally) {
 
-            Button(
-                onClick = {
-                  showParentDialog.value = false
-                  Toast.makeText(context, "Not yet implemented", Toast.LENGTH_SHORT).show()
-                },
-                colors = ColorPalette.BUTTON_COLOR) {
-                  Text("Log-out")
-                }
+        // Settings content
+        if (currentUser == null) {
+          Text(
+              text = context.getString(R.string.SettingsNullUserContent),
+              modifier = Modifier.testTag("NullUserSettingsContent"))
+        } else {
+          Text(
+              context.getString(R.string.SettingsConnectionContent, currentUser.username),
+              modifier = Modifier.padding(bottom = 16.dp).testTag("ConnectionSettingsContent"))
 
-            Button(
-                onClick = { showConfirmUserDelete.value = true },
-                colors = ColorPalette.BUTTON_COLOR) {
-                  Text("Delete account")
-                }
-          }
+          Button(
+              onClick = {
+                showParentDialog.value = false
+                Toast.makeText(context, "Not yet implemented", Toast.LENGTH_SHORT).show()
+              },
+              colors = ColorPalette.BUTTON_COLOR,
+              modifier = Modifier.testTag("LogOutButton")) {
+                Text("Log-out")
+              }
+
+          Button(
+              onClick = { showConfirmUserDelete.value = true },
+              colors = ColorPalette.BUTTON_COLOR,
+              modifier = Modifier.testTag("DeleteAccountButton")) {
+                Text("Delete account")
+              }
         }
+      }
 
-    CustomDialog(
-        showConfirmUserDelete,
-        DialogType.CONFIRM,
-        tag = "deleteAccount",
-        title = context.getString(R.string.DeleteAccountConfirmationTitle),
-        Content = { Text(context.getString(R.string.DeleteAccountConfirmationContent)) },
-        onSubmit = {
-          // Friends - remove user from friends list of all friends.
-          // Parks - remove user ratings for parks.
-          // Parks - remove user in participants of each event.
-          // Progression - delete user progression
-          // userViewModel.deleteUser(currentUser)
+  CustomDialog(
+      showConfirmUserDelete,
+      DialogType.CONFIRM,
+      tag = "deleteAccount",
+      title = context.getString(R.string.DeleteAccountConfirmationTitle),
+      Content = { Text(context.getString(R.string.DeleteAccountConfirmationContent)) },
+      onSubmit = {
+        // Friends - remove user from friends list of all friends.
+        // Parks - remove user ratings for parks.
+        // Parks - remove user in participants of each event.
+        // Progression - delete user progression
+        // userViewModel.deleteUser(currentUser)
 
-          Toast.makeText(context, "Not yet implemented", Toast.LENGTH_SHORT).show()
+        Toast.makeText(context, "Not yet implemented", Toast.LENGTH_SHORT).show()
 
-          showParentDialog.value = false
-          // navigationActions.navigateTo(Screen.AUTH)
-        })
-  }
+        showParentDialog.value = false
+        // navigationActions.navigateTo(Screen.AUTH)
+      })
 }

--- a/app/src/main/java/com/android/streetworkapp/ui/profile/Settings.kt
+++ b/app/src/main/java/com/android/streetworkapp/ui/profile/Settings.kt
@@ -15,6 +15,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
+import com.android.sample.R
 import com.android.streetworkapp.model.user.UserViewModel
 import com.android.streetworkapp.ui.navigation.NavigationActions
 import com.android.streetworkapp.ui.theme.ColorPalette
@@ -28,11 +29,10 @@ fun SettingsContent(
     showParentDialog: MutableState<Boolean>
 ) {
   Column() {
-    // Selector  for settings :
-
     val currentUser = remember { userViewModel.currentUser.value }
     val showConfirmUserDelete = remember { mutableStateOf(false) }
     val context = LocalContext.current
+
     Column(
         modifier = Modifier.fillMaxWidth(),
         verticalArrangement = Arrangement.spacedBy(4.dp),
@@ -40,10 +40,10 @@ fun SettingsContent(
 
           // Settings content
           if (currentUser == null) {
-            Text("You are not logged-in, please log-in to access connection settings")
+            Text(context.getString(R.string.SettingsNullUserContent))
           } else {
             Text(
-                "You are logged-in as ${currentUser.username}",
+                context.getString(R.string.SettingsConnectionContent),
                 modifier = Modifier.padding(bottom = 16.dp))
 
             Button(
@@ -67,11 +67,8 @@ fun SettingsContent(
         showConfirmUserDelete,
         DialogType.CONFIRM,
         tag = "deleteAccount",
-        title = "Are you sure ?",
-        Content = {
-          Text(
-              "Are you sure you want to delete your account ?\n\n You will loose all of your progression \n\nThis action is irreversible.")
-        },
+        title = context.getString(R.string.DeleteAccountConfirmationTitle),
+        Content = { Text(context.getString(R.string.DeleteAccountConfirmationContent)) },
         onSubmit = {
           // Friends - remove user from friends list of all friends.
           // Parks - remove user ratings for parks.

--- a/app/src/main/java/com/android/streetworkapp/ui/profile/Settings.kt
+++ b/app/src/main/java/com/android/streetworkapp/ui/profile/Settings.kt
@@ -1,0 +1,88 @@
+package com.android.streetworkapp.ui.profile
+
+import android.widget.Toast
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+import com.android.streetworkapp.model.user.UserViewModel
+import com.android.streetworkapp.ui.navigation.NavigationActions
+import com.android.streetworkapp.ui.theme.ColorPalette
+import com.android.streetworkapp.ui.utils.CustomDialog
+import com.android.streetworkapp.ui.utils.DialogType
+
+@Composable
+fun SettingsContent(
+    navigationActions: NavigationActions,
+    userViewModel: UserViewModel,
+    showParentDialog: MutableState<Boolean>
+) {
+  Column() {
+    // Selector  for settings :
+
+    val currentUser = remember { userViewModel.currentUser.value }
+    val showConfirmUserDelete = remember { mutableStateOf(false) }
+    val context = LocalContext.current
+    Column(
+        modifier = Modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(4.dp),
+        horizontalAlignment = Alignment.CenterHorizontally) {
+
+          // Settings content
+          if (currentUser == null) {
+            Text("You are not logged-in, please log-in to access connection settings")
+          } else {
+            Text(
+                "You are logged-in as ${currentUser.username}",
+                modifier = Modifier.padding(bottom = 16.dp))
+
+            Button(
+                onClick = {
+                  showParentDialog.value = false
+                  Toast.makeText(context, "Not yet implemented", Toast.LENGTH_SHORT).show()
+                },
+                colors = ColorPalette.BUTTON_COLOR) {
+                  Text("Log-out")
+                }
+
+            Button(
+                onClick = { showConfirmUserDelete.value = true },
+                colors = ColorPalette.BUTTON_COLOR) {
+                  Text("Delete account")
+                }
+          }
+        }
+
+    CustomDialog(
+        showConfirmUserDelete,
+        DialogType.CONFIRM,
+        tag = "deleteAccount",
+        title = "Are you sure ?",
+        Content = {
+          Text(
+              "Are you sure you want to delete your account ?\n\n You will loose all of your progression \n\nThis action is irreversible.")
+        },
+        onSubmit = {
+          // Friends - remove user from friends list of all friends.
+          // Parks - remove user ratings for parks.
+          // Parks - remove user in participants of each event.
+          // Progression - delete user progression
+          // userViewModel.deleteUser(currentUser)
+
+          Toast.makeText(context, "Not yet implemented", Toast.LENGTH_SHORT).show()
+
+          showParentDialog.value = false
+          // navigationActions.navigateTo(Screen.AUTH)
+        })
+  }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -11,7 +11,7 @@
     <string name="SettingsConnectionContent">You are logged-in as %1$s</string>
 
     <string name="DeleteAccountConfirmationTitle">Are you sure ?</string>
-    <string name="DeleteAccountConfirmationContent">Do you really want to delete your account ? \n\nYou will loose all of your progression \n\nThis action is irreversible.</string>
+    <string name="DeleteAccountConfirmationContent">Do you really want to delete your account ? \n\nYou will loose all of your progression. \nThis action is irreversible.</string>
 
 
     // Friend removal :

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -4,6 +4,16 @@
     <string name="title_activity_second">SecondActivity</string>
     <string name="default_web_client_id">949532445294-2cvshtbsgubvrn54cg9301rrs2pe8dth.apps.googleusercontent.com</string>
 
+
+    // Settings
+    <string name="SettingsTitle">Settings</string>
+    <string name="SettingsNullUserContent">You are not logged-in, please log-in to access connection settings</string>
+    <string name="SettingsConnectionContent">You are logged-in as %1$s</string>
+
+    <string name="DeleteAccountConfirmationTitle">Are you sure ?</string>
+    <string name="DeleteAccountConfirmationContent">Do you really want to delete your account ? \n\nYou will loose all of your progression \n\nThis action is irreversible.</string>
+
+
     // Friend removal :
     <string name="RemoveFriendAction">Remove friend</string>
     <string name="RemoveFriendSuccess">Removed %1$s from your friends</string>
@@ -12,7 +22,6 @@
     // Friend removal dialog
     <string name="RemoveFriendTitle">Are you sure ?</string>
     <string name="RemoveFriendContent">Do you really want to remove %1$s from your friends ?</string>
-
 
 
     // Dialogs
@@ -53,9 +62,6 @@
 
     // Progression UI
     <string name="ProgressionEmptyAchievements">You do not have any achievements yet!</string>
-
-
-
 
 
 </resources>


### PR DESCRIPTION
## Description

This PR aims to implement the UI for the first settings of the app : 

- **Logout Button** - whose logic is not implemented in this PR.
- **Delete account Button** - Which calls a Dialog (pop-up) that asks for confirmation before exectuing a callback function. Real deletion is not implemented in this PR.

### Test
New test has been made in `SettingsTest`.

### Testing the feature

- In the profile, clicking on the gear icon should open the settings.
- Clicking on "delete account" should open a confirmation pop-up.

<p align="center">
<img src="https://github.com/user-attachments/assets/84c0b59c-ab90-44f2-87f6-713bffcb9b36" alt="image" width="195">
<img src="https://github.com/user-attachments/assets/0948664f-6dac-4056-b102-ea319a4497af" alt="image" width="195">
<img src="https://github.com/user-attachments/assets/59384731-4a27-4faa-8bc5-9c0febf05523" alt="image" width="195">
</p>