### PR TITLE
Refactor/merge checkFriend and checkScore in Progression MVVM 

### DIFF
--- a/app/src/main/java/com/android/streetworkapp/model/progression/Progression.kt
+++ b/app/src/main/java/com/android/streetworkapp/model/progression/Progression.kt
@@ -47,11 +47,7 @@ enum class Ranks(val score: Int) {
 
 /** Represents a type of achievement based on points obtained */
 enum class MedalsAchievement(val achievement: Achievement, val rank: Ranks) {
-  // Note: Bronze is used as a place holder for missing medals in the Figma (will be updated once
-  // the figma is updated)
-  NONE(
-      Achievement(R.drawable.bronze_achievement_icon, "No Medal", emptyList(), "Default Medal"),
-      Ranks.CEILING),
+
   BRONZE(
       Achievement(
           R.drawable.bronze_achievement_icon,

--- a/app/src/main/java/com/android/streetworkapp/model/progression/Progression.kt
+++ b/app/src/main/java/com/android/streetworkapp/model/progression/Progression.kt
@@ -46,39 +46,40 @@ enum class Ranks(val score: Int) {
 }
 
 /** Represents a type of achievement based on points obtained */
-enum class MedalsAchievement(val achievement: Achievement) {
+enum class MedalsAchievement(val achievement: Achievement, val rank: Ranks) {
   // Note: Bronze is used as a place holder for missing medals in the Figma (will be updated once
   // the figma is updated)
   NONE(
-      Achievement(
-          R.drawable.bronze_achievement_icon,
-          "No Medal",
-          emptyList(),
-          "You have no medal yet, try to obtain more points!")),
+      Achievement(R.drawable.bronze_achievement_icon, "No Medal", emptyList(), "Default Medal"),
+      Ranks.CEILING),
   BRONZE(
       Achievement(
           R.drawable.bronze_achievement_icon,
           "Bronze Medal",
           listOf("Bronze"),
-          "You obtained 100 Points!")),
+          "You obtained 100 Points!"),
+      Ranks.BRONZE),
   SILVER(
       Achievement(
           R.drawable.silver_achievement_icon,
           "Silver Medal",
           listOf("Silver"),
-          "You obtained 1000 Points!")),
+          "You obtained 1000 Points!"),
+      Ranks.SILVER),
   GOLD(
       Achievement(
           R.drawable.gold_achievement_icon,
           "Gold Medal",
           listOf("Gold"),
-          "You obtained 10000 Points!")),
+          "You obtained 10000 Points!"),
+      Ranks.GOLD),
   PLATINUM(
       Achievement(
           R.drawable.bronze_achievement_icon,
           "Platinum Medal",
           listOf("Platinum"),
-          "You obtained 100000 Points!"))
+          "You obtained 100000 Points!"),
+      Ranks.PLATINUM)
 }
 
 /** Represents a type of achievement linked to the performance of the user on different exercises */

--- a/app/src/main/java/com/android/streetworkapp/model/progression/ProgressionViewModel.kt
+++ b/app/src/main/java/com/android/streetworkapp/model/progression/ProgressionViewModel.kt
@@ -36,53 +36,6 @@ open class ProgressionViewModel(private val repository: ProgressionRepository) :
   }
 
   /**
-   * Check the score of the user. With enough points, the user wins medals. This function should be
-   * called EACH TIME points are added
-   *
-   * @param score: The current score of the user
-   */
-  fun checkScore(score: Int) =
-      viewModelScope.launch {
-        while (_currentProgression.value.currentGoal < score && score <= Ranks.CEILING.score) {
-          val unlockedAchievement = getMedalByScore(_currentProgression.value.currentGoal)
-          val nextMedalName =
-              enumValues<MedalsAchievement>().getOrNull(unlockedAchievement.ordinal + 1)?.name
-          nextMedalName
-              ?.let { // if this executes this means that the user is not at the highest rank
-                val newAchievements =
-                    _currentProgression.value.achievements + unlockedAchievement.name
-                _currentProgression.value.currentGoal = enumValueOf<Ranks>(it).score
-
-                repository.updateProgressionWithAchievementAndGoal(
-                    _currentProgression.value.progressionId,
-                    newAchievements,
-                    _currentProgression.value.currentGoal)
-              }
-        }
-      }
-
-  /**
-   * Check the number of friends of the user. Gives an achievement when the user as enough friends
-   *
-   * @param numberOfFriends: The current numberOfFriends of the user
-   */
-  fun checkFriends(numberOfFriends: Int) =
-      viewModelScope.launch {
-        val newAchievements = _currentProgression.value.achievements.toMutableList()
-
-        enumValues<SocialAchievement>().forEach {
-          if (it.numberOfFriends <= numberOfFriends && !newAchievements.contains(it.name)) {
-            newAchievements += it.name
-          }
-        }
-
-        repository.updateProgressionWithAchievementAndGoal(
-            _currentProgression.value.progressionId,
-            newAchievements,
-            _currentProgression.value.currentGoal)
-      }
-
-  /**
    * Checks if the user have won achievements
    *
    * @param numberOfFriends: The current numberOfFriends of the user

--- a/app/src/main/java/com/android/streetworkapp/model/progression/ProgressionViewModel.kt
+++ b/app/src/main/java/com/android/streetworkapp/model/progression/ProgressionViewModel.kt
@@ -4,7 +4,6 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.android.streetworkapp.model.progression.MedalsAchievement.BRONZE
 import com.android.streetworkapp.model.progression.MedalsAchievement.GOLD
-import com.android.streetworkapp.model.progression.MedalsAchievement.NONE
 import com.android.streetworkapp.model.progression.MedalsAchievement.PLATINUM
 import com.android.streetworkapp.model.progression.MedalsAchievement.SILVER
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -80,6 +79,6 @@ fun getMedalByScore(score: Int): MedalsAchievement {
     Ranks.SILVER.score -> SILVER
     Ranks.GOLD.score -> GOLD
     Ranks.PLATINUM.score -> PLATINUM
-    else -> NONE
+    else -> PLATINUM
   }
 }

--- a/app/src/main/java/com/android/streetworkapp/model/progression/ProgressionViewModel.kt
+++ b/app/src/main/java/com/android/streetworkapp/model/progression/ProgressionViewModel.kt
@@ -81,6 +81,39 @@ open class ProgressionViewModel(private val repository: ProgressionRepository) :
             newAchievements,
             _currentProgression.value.currentGoal)
       }
+
+  /**
+   * Checks if the user have won achievements
+   *
+   * @param numberOfFriends: The current numberOfFriends of the user
+   * @param score: The current score of the user
+   */
+  fun checkAchievements(numberOfFriends: Int, score: Int) =
+      viewModelScope.launch {
+        val newAchievements = _currentProgression.value.achievements.toMutableList()
+
+        enumValues<SocialAchievement>().forEach {
+          if (it.numberOfFriends <= numberOfFriends && !newAchievements.contains(it.name)) {
+            newAchievements += it.name
+          }
+        }
+
+        enumValues<MedalsAchievement>().forEach {
+          if (it.rank.score <= score && !newAchievements.contains(it.name)) {
+            newAchievements += it.name
+            val nextMedal = enumValues<MedalsAchievement>().getOrNull(it.ordinal + 1)
+
+            if (nextMedal != null) {
+              _currentProgression.value.currentGoal = nextMedal.rank.score
+            }
+          }
+        }
+
+        repository.updateProgressionWithAchievementAndGoal(
+            _currentProgression.value.progressionId,
+            newAchievements,
+            _currentProgression.value.currentGoal)
+      }
 }
 
 /**

--- a/app/src/main/java/com/android/streetworkapp/ui/progress/Gamification.kt
+++ b/app/src/main/java/com/android/streetworkapp/ui/progress/Gamification.kt
@@ -5,10 +5,19 @@ import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.SnackbarResult
 import com.android.streetworkapp.model.user.UserViewModel
 import com.android.streetworkapp.ui.navigation.NavigationActions
-import com.android.streetworkapp.ui.navigation.Screen
+import com.android.streetworkapp.ui.navigation.TopLevelDestinations
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 
+/**
+ * Use this function to give points to the user and to display it with a SnackBar.
+ *
+ * @param userViewModel: The userViewModel
+ * @param navigationActions: Used to go see the progression screen.
+ * @param points: Points obtained by the user.
+ * @param scope: Used to display the SnackBar.
+ * @param snackbarHostState: Used to display the SnackBar.
+ */
 fun updateAndDisplayPoints(
     userViewModel: UserViewModel,
     navigationActions: NavigationActions,
@@ -29,7 +38,7 @@ fun updateAndDisplayPoints(
     when (result) {
       SnackbarResult.Dismissed -> {}
       SnackbarResult.ActionPerformed -> {
-        navigationActions.navigateTo(Screen.PROGRESSION)
+        navigationActions.navigateTo(TopLevelDestinations.PROGRESSION)
       }
     }
   }

--- a/app/src/main/java/com/android/streetworkapp/ui/progress/Progression.kt
+++ b/app/src/main/java/com/android/streetworkapp/ui/progress/Progression.kt
@@ -27,6 +27,7 @@ import androidx.compose.material3.NavigationBar
 import androidx.compose.material3.NavigationBarItem
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
@@ -81,10 +82,12 @@ fun ProgressScreen(
   val currentUser by userViewModel.currentUser.collectAsState()
   val currentProgression by progressionViewModel.currentProgression.collectAsState()
 
-  currentUser?.uid?.let { progressionViewModel.getOrAddProgression(it) }
-  // currentUser?.let { progressionViewModel.checkScore(it.score) }
-  // currentUser?.let { progressionViewModel.checkFriends(it.friends.size) }
-  currentUser?.let { progressionViewModel.checkAchievements(it.friends.size, it.score) }
+  LaunchedEffect(currentProgression) {
+    currentUser?.let {
+      progressionViewModel.getOrAddProgression(it.uid)
+      progressionViewModel.checkAchievements(it.friends.size, it.score)
+    }
+  }
 
   val progressionPercentage = // in case of error set it to 0, otherwise score/currentGoal
       (if (currentUser == null || currentProgression.currentGoal == 0) 0f
@@ -154,6 +157,9 @@ fun ProgressScreen(
           item {
             when (uiState.collectAsState().value) {
               DashboardStateProgression.Achievement -> {
+                currentUser?.let {
+                  progressionViewModel.checkAchievements(it.friends.size, it.score)
+                }
 
                 AchievementColumn(currentProgression.achievements)
               }

--- a/app/src/main/java/com/android/streetworkapp/ui/progress/Progression.kt
+++ b/app/src/main/java/com/android/streetworkapp/ui/progress/Progression.kt
@@ -82,8 +82,9 @@ fun ProgressScreen(
   val currentProgression by progressionViewModel.currentProgression.collectAsState()
 
   currentUser?.uid?.let { progressionViewModel.getOrAddProgression(it) }
-  currentUser?.let { progressionViewModel.checkScore(it.score) }
-  currentUser?.let { progressionViewModel.checkFriends(it.friends.size) }
+  // currentUser?.let { progressionViewModel.checkScore(it.score) }
+  // currentUser?.let { progressionViewModel.checkFriends(it.friends.size) }
+  currentUser?.let { progressionViewModel.checkAchievements(it.friends.size, it.score) }
 
   val progressionPercentage = // in case of error set it to 0, otherwise score/currentGoal
       (if (currentUser == null || currentProgression.currentGoal == 0) 0f

--- a/app/src/test/java/com/android/streetworkapp/model/progression/ProgressionViewModelTest.kt
+++ b/app/src/test/java/com/android/streetworkapp/model/progression/ProgressionViewModelTest.kt
@@ -49,7 +49,6 @@ class ProgressionViewModelTest {
 
   @Test
   fun getMedalTest() = runTest {
-    assertEquals(MedalsAchievement.NONE, getMedalByScore(0))
     assertEquals(MedalsAchievement.BRONZE, getMedalByScore(100))
     assertEquals(MedalsAchievement.SILVER, getMedalByScore(1000))
     assertEquals(MedalsAchievement.GOLD, getMedalByScore(10000))

--- a/app/src/test/java/com/android/streetworkapp/model/progression/ProgressionViewModelTest.kt
+++ b/app/src/test/java/com/android/streetworkapp/model/progression/ProgressionViewModelTest.kt
@@ -41,8 +41,8 @@ class ProgressionViewModelTest {
   }
 
   @Test
-  fun checkScoreCallsRepository() = runTest {
-    progressionViewModel.checkScore(1000)
+  fun checkAchievementCallsRepository() = runTest {
+    progressionViewModel.checkAchievements(0, 1000)
     testDispatcher.scheduler.advanceUntilIdle()
     verify(repository).updateProgressionWithAchievementAndGoal(any(), any(), any())
   }


### PR DESCRIPTION
## Overview

The objective of this pull request is to merge the function `checkFriend` and the function `checkScore` from the progression MVVM into a unique function called `checkAchievements.` When the two function were different, there was situations were the achievements from the first one would overwrite the achievement of the second one in the Database, especially if the user won the two different kind of achievement at the same time.

This Pull Request also fix a small typo in the navigation of the gamification function used for updating the progression.

## Changes

- A new function `checkAchievements,` that is a merge of `checkScore` and `checkFriend`
- An update of the test to use checkAchievements
- Use of `TopLevelDestinations.PROGRESSION` in the gamification, rather than the `Screen.PROGRESSION`

## How to test

The medals and the social achievements should be correctly displayed, particularly when the two kind of achievements are obtained at the same time.
