### PR TITLE
Feat/ Create achievements for training with the app

### DIFF
--- a/app/src/androidTest/java/com/android/streetworkapp/ui/Progression/ProgressionTest.kt
+++ b/app/src/androidTest/java/com/android/streetworkapp/ui/Progression/ProgressionTest.kt
@@ -57,6 +57,16 @@ class ProgressionTest {
   val uid = "testUid"
   private val sessionId = "testSessionId"
   private val exercise = Exercise(name = "Push-ups", duration = 30)
+  private val exercise2 = Exercise(name = "Dips")
+  private val exercise3 = Exercise(name = "Burpee")
+  private val exercise4 = Exercise(name = "Lunge")
+  private val exercise5 = Exercise(name = "Planks")
+  private val exercise6 = Exercise(name = "Handstand")
+  private val exercise7 = Exercise(name = "Front lever")
+  private val exercise8 = Exercise(name = "Flag")
+  private val exercise9 = Exercise(name = "Muscle-up")
+  private val exerciseNew = Exercise(name = "NewExercise")
+
   private val sessionType = SessionType.SOLO
 
   private val existingSession =
@@ -66,7 +76,18 @@ class ProgressionTest {
           endTime = 0L,
           sessionType = sessionType,
           participants = listOf("testParticipant"),
-          exercises = listOf(exercise),
+          exercises =
+              listOf(
+                  exercise,
+                  exercise2,
+                  exercise3,
+                  exercise4,
+                  exercise5,
+                  exercise6,
+                  exercise7,
+                  exercise8,
+                  exercise9,
+                  exerciseNew),
           winner = null)
   private val workoutData = WorkoutData(userUid = uid, workoutSessions = listOf(existingSession))
 
@@ -229,7 +250,7 @@ class ProgressionTest {
 
     workoutData.workoutSessions.forEach { workoutSession ->
       workoutSession.exercises.forEach {
-        composeTestRule.onNodeWithTag("exerciseItem${it.name}").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("exerciseItem${it.name}").assertExists()
       }
     }
   }

--- a/app/src/androidTest/java/com/android/streetworkapp/ui/Progression/ProgressionTest.kt
+++ b/app/src/androidTest/java/com/android/streetworkapp/ui/Progression/ProgressionTest.kt
@@ -6,7 +6,6 @@ import androidx.compose.ui.test.assertTextEquals
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
-import com.android.streetworkapp.model.progression.ExerciseAchievement
 import com.android.streetworkapp.model.progression.MedalsAchievement
 import com.android.streetworkapp.model.progression.Progression
 import com.android.streetworkapp.model.progression.ProgressionRepositoryFirestore
@@ -183,14 +182,13 @@ class ProgressionTest {
 
     composeTestRule.onNodeWithTag("TrainingTab").performClick()
 
-      /*
+    /*
     enumValues<ExerciseAchievement>().forEach { exercise ->
       composeTestRule.onNodeWithTag("exerciseItem" + exercise.name).assertExists()
     }
     TODO: update with new kind of exercise
 
        */
-
 
   }
 

--- a/app/src/androidTest/java/com/android/streetworkapp/ui/Progression/ProgressionTest.kt
+++ b/app/src/androidTest/java/com/android/streetworkapp/ui/Progression/ProgressionTest.kt
@@ -183,9 +183,15 @@ class ProgressionTest {
 
     composeTestRule.onNodeWithTag("TrainingTab").performClick()
 
+      /*
     enumValues<ExerciseAchievement>().forEach { exercise ->
       composeTestRule.onNodeWithTag("exerciseItem" + exercise.name).assertExists()
     }
+    TODO: update with new kind of exercise
+
+       */
+
+
   }
 
   @Test

--- a/app/src/androidTest/java/com/android/streetworkapp/ui/Progression/ProgressionTest.kt
+++ b/app/src/androidTest/java/com/android/streetworkapp/ui/Progression/ProgressionTest.kt
@@ -116,6 +116,8 @@ class ProgressionTest {
             winner = null)
     val workoutData = WorkoutData(userUid = uid, workoutSessions = listOf(existingSession))
 
+    coEvery { workoutRepository.getOrAddWorkoutData(any()) } answers { workoutData }
+
     progressionViewModel = ProgressionViewModel(progressionRepository)
   }
 
@@ -127,7 +129,7 @@ class ProgressionTest {
           Progression()
         }
     composeTestRule.setContent {
-      ProgressScreen(navigationActions, userViewModel, progressionViewModel)
+      ProgressScreen(navigationActions, userViewModel, progressionViewModel, workoutViewModel)
     }
     composeTestRule.onNodeWithTag("progressionScreen").assertIsDisplayed()
   }
@@ -141,7 +143,7 @@ class ProgressionTest {
         }
 
     composeTestRule.setContent {
-      ProgressScreen(navigationActions, userViewModel, progressionViewModel)
+      ProgressScreen(navigationActions, userViewModel, progressionViewModel, workoutViewModel)
     }
     composeTestRule.onNodeWithTag("progressionScreen").assertIsDisplayed()
     composeTestRule.onNodeWithTag("circularProgressBar").assertIsDisplayed()
@@ -169,7 +171,7 @@ class ProgressionTest {
         }
 
     composeTestRule.setContent {
-      ProgressScreen(navigationActions, userViewModel, progressionViewModel)
+      ProgressScreen(navigationActions, userViewModel, progressionViewModel, workoutViewModel)
     }
 
     composeTestRule.onNodeWithTag("AchievementTab").performClick()
@@ -217,7 +219,7 @@ class ProgressionTest {
         }
 
     composeTestRule.setContent {
-      ProgressScreen(navigationActions, userViewModel, progressionViewModel)
+      ProgressScreen(navigationActions, userViewModel, progressionViewModel, workoutViewModel)
     }
     composeTestRule.onNodeWithTag("AchievementTab").performClick()
 
@@ -273,7 +275,7 @@ class ProgressionTest {
         }
 
     composeTestRule.setContent {
-      ProgressScreen(navigationActions, userViewModel, progressionViewModel)
+      ProgressScreen(navigationActions, userViewModel, progressionViewModel, workoutViewModel)
     }
 
     composeTestRule.onNodeWithTag("AchievementTab").performClick()

--- a/app/src/main/java/com/android/streetworkapp/MainActivity.kt
+++ b/app/src/main/java/com/android/streetworkapp/MainActivity.kt
@@ -311,7 +311,12 @@ fun StreetWorkApp(
           navigation(startDestination = Screen.PROGRESSION, route = Route.PROGRESSION) {
             composable(Screen.PROGRESSION) {
               infoManager.Display(LocalContext.current)
-              ProgressScreen(navigationActions, userViewModel, progressionViewModel, innerPadding)
+              ProgressScreen(
+                  navigationActions,
+                  userViewModel,
+                  progressionViewModel,
+                  workoutViewModel,
+                  innerPadding)
             }
           }
           navigation(

--- a/app/src/main/java/com/android/streetworkapp/ui/progress/Progression.kt
+++ b/app/src/main/java/com/android/streetworkapp/ui/progress/Progression.kt
@@ -54,8 +54,11 @@ import com.android.streetworkapp.model.progression.MedalsAchievement
 import com.android.streetworkapp.model.progression.ProgressionViewModel
 import com.android.streetworkapp.model.progression.SocialAchievement
 import com.android.streetworkapp.model.user.UserViewModel
+import com.android.streetworkapp.model.workout.WorkoutRepositoryFirestore
+import com.android.streetworkapp.model.workout.WorkoutViewModel
 import com.android.streetworkapp.ui.navigation.NavigationActions
 import com.android.streetworkapp.ui.theme.ColorPalette
+import com.google.firebase.firestore.FirebaseFirestore
 import kotlinx.coroutines.flow.MutableStateFlow
 
 object ProgressionScreenSettings {
@@ -76,6 +79,8 @@ fun ProgressScreen(
     navigationActions: NavigationActions, // Note: not used yet
     userViewModel: UserViewModel,
     progressionViewModel: ProgressionViewModel,
+    workoutViewModel: WorkoutViewModel =
+        WorkoutViewModel(WorkoutRepositoryFirestore(FirebaseFirestore.getInstance())),
     paddingValues: PaddingValues = PaddingValues(0.dp)
 ) {
 

--- a/app/src/main/java/com/android/streetworkapp/ui/progress/Progression.kt
+++ b/app/src/main/java/com/android/streetworkapp/ui/progress/Progression.kt
@@ -49,7 +49,6 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.android.sample.R
 import com.android.streetworkapp.model.progression.Achievement
-import com.android.streetworkapp.model.progression.ExerciseAchievement
 import com.android.streetworkapp.model.progression.MedalsAchievement
 import com.android.streetworkapp.model.progression.ProgressionViewModel
 import com.android.streetworkapp.model.progression.SocialAchievement
@@ -58,6 +57,7 @@ import com.android.streetworkapp.model.workout.WorkoutRepositoryFirestore
 import com.android.streetworkapp.model.workout.WorkoutViewModel
 import com.android.streetworkapp.ui.navigation.NavigationActions
 import com.android.streetworkapp.ui.theme.ColorPalette
+import com.android.streetworkapp.utils.toFormattedString
 import com.google.firebase.firestore.FirebaseFirestore
 import kotlinx.coroutines.flow.MutableStateFlow
 
@@ -86,6 +86,9 @@ fun ProgressScreen(
 
   val currentUser by userViewModel.currentUser.collectAsState()
   val currentProgression by progressionViewModel.currentProgression.collectAsState()
+
+  val currentWorkout by workoutViewModel.workoutData.collectAsState()
+  currentUser?.uid?.let { workoutViewModel.getOrAddWorkoutData(it) }
 
   LaunchedEffect(currentProgression) {
     currentUser?.let {
@@ -170,6 +173,24 @@ fun ProgressScreen(
               }
               DashboardStateProgression.Training -> {
 
+                currentWorkout?.workoutSessions?.forEach { workout ->
+                  val date = workout.startTime.toFormattedString()
+                  workout.exercises.forEach {
+                    val newAchievement =
+                        Achievement(
+                            exerciseNameToIcon(it.name),
+                            "You trained your ${it.name} !",
+                            listOf("workout"),
+                            date)
+
+                    Box(modifier = Modifier.testTag("exerciseItem")) {
+                      AchievementItem(newAchievement, false)
+                      HorizontalDivider(thickness = 0.5.dp, color = Color.LightGray)
+                    }
+                  }
+                }
+
+                /*
                 enumValues<ExerciseAchievement>().forEach {
                   it.achievement.description =
                       "Record : 0.0 sec" // TODO: use the progression MVVM with current record
@@ -178,6 +199,9 @@ fun ProgressScreen(
                     HorizontalDivider(thickness = 0.5.dp, color = Color.LightGray)
                   }
                 }
+
+                   */
+
               }
             }
           }
@@ -374,4 +398,19 @@ sealed class DashboardStateProgression {
   data object Training : DashboardStateProgression()
 
   data object Achievement : DashboardStateProgression()
+}
+
+fun exerciseNameToIcon(name: String): Int {
+  return when (name) {
+    "Push-ups" -> R.drawable.train_pushup
+    "Dips" -> R.drawable.train_dips
+    "Burpee" -> R.drawable.train_burpee
+    "Lunge" -> R.drawable.train_lunge
+    "Planks" -> R.drawable.train_planks
+    "Handstand" -> R.drawable.train_hand_stand
+    "Front lever" -> R.drawable.train_front_lever
+    "Flag" -> R.drawable.train_flag
+    "Muscle-up" -> R.drawable.train_muscle_up
+    else -> R.drawable.handstand_org
+  }
 }

--- a/app/src/main/java/com/android/streetworkapp/ui/progress/Progression.kt
+++ b/app/src/main/java/com/android/streetworkapp/ui/progress/Progression.kt
@@ -176,7 +176,7 @@ fun ProgressScreen(
                     val newAchievement =
                         Achievement(
                             exerciseNameToIcon(it.name),
-                            "You trained your ${it.name} !",
+                            LocalContext.current.getString(R.string.Trained, it.name),
                             listOf("workout"),
                             date)
 
@@ -384,17 +384,23 @@ sealed class DashboardStateProgression {
   data object Achievement : DashboardStateProgression()
 }
 
+/**
+ * This function can be used to find the Icon corresponding to a given exercise name.
+ *
+ * @param name: The exercise name
+ */
+@Composable
 fun exerciseNameToIcon(name: String): Int {
   return when (name) {
-    "Push-ups" -> R.drawable.train_pushup
-    "Dips" -> R.drawable.train_dips
-    "Burpee" -> R.drawable.train_burpee
-    "Lunge" -> R.drawable.train_lunge
-    "Planks" -> R.drawable.train_planks
-    "Handstand" -> R.drawable.train_hand_stand
-    "Front lever" -> R.drawable.train_front_lever
-    "Flag" -> R.drawable.train_flag
-    "Muscle-up" -> R.drawable.train_muscle_up
+    LocalContext.current.getString(R.string.Pushups) -> R.drawable.train_pushup
+    LocalContext.current.getString(R.string.Dips) -> R.drawable.train_dips
+    LocalContext.current.getString(R.string.Burpee) -> R.drawable.train_burpee
+    LocalContext.current.getString(R.string.Lunge) -> R.drawable.train_lunge
+    LocalContext.current.getString(R.string.Planks) -> R.drawable.train_planks
+    LocalContext.current.getString(R.string.Handstand) -> R.drawable.train_hand_stand
+    LocalContext.current.getString(R.string.Frontlever) -> R.drawable.train_front_lever
+    LocalContext.current.getString(R.string.Flag) -> R.drawable.train_flag
+    LocalContext.current.getString(R.string.Muscleup) -> R.drawable.train_muscle_up
     else -> R.drawable.handstand_org
   }
 }

--- a/app/src/main/java/com/android/streetworkapp/ui/progress/Progression.kt
+++ b/app/src/main/java/com/android/streetworkapp/ui/progress/Progression.kt
@@ -183,25 +183,12 @@ fun ProgressScreen(
                             listOf("workout"),
                             date)
 
-                    Box(modifier = Modifier.testTag("exerciseItem")) {
+                    Box(modifier = Modifier.testTag("exerciseItem${it.name}")) {
                       AchievementItem(newAchievement, false)
                       HorizontalDivider(thickness = 0.5.dp, color = Color.LightGray)
                     }
                   }
                 }
-
-                /*
-                enumValues<ExerciseAchievement>().forEach {
-                  it.achievement.description =
-                      "Record : 0.0 sec" // TODO: use the progression MVVM with current record
-                  Box(modifier = Modifier.testTag("exerciseItem${it.name}")) {
-                    AchievementItem(it.achievement, true)
-                    HorizontalDivider(thickness = 0.5.dp, color = Color.LightGray)
-                  }
-                }
-
-                   */
-
               }
             }
           }

--- a/app/src/main/java/com/android/streetworkapp/ui/progress/Progression.kt
+++ b/app/src/main/java/com/android/streetworkapp/ui/progress/Progression.kt
@@ -53,12 +53,10 @@ import com.android.streetworkapp.model.progression.MedalsAchievement
 import com.android.streetworkapp.model.progression.ProgressionViewModel
 import com.android.streetworkapp.model.progression.SocialAchievement
 import com.android.streetworkapp.model.user.UserViewModel
-import com.android.streetworkapp.model.workout.WorkoutRepositoryFirestore
 import com.android.streetworkapp.model.workout.WorkoutViewModel
 import com.android.streetworkapp.ui.navigation.NavigationActions
 import com.android.streetworkapp.ui.theme.ColorPalette
 import com.android.streetworkapp.utils.toFormattedString
-import com.google.firebase.firestore.FirebaseFirestore
 import kotlinx.coroutines.flow.MutableStateFlow
 
 object ProgressionScreenSettings {
@@ -79,8 +77,7 @@ fun ProgressScreen(
     navigationActions: NavigationActions, // Note: not used yet
     userViewModel: UserViewModel,
     progressionViewModel: ProgressionViewModel,
-    workoutViewModel: WorkoutViewModel =
-        WorkoutViewModel(WorkoutRepositoryFirestore(FirebaseFirestore.getInstance())),
+    workoutViewModel: WorkoutViewModel,
     paddingValues: PaddingValues = PaddingValues(0.dp)
 ) {
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -62,6 +62,18 @@
 
     // Progression UI
     <string name="ProgressionEmptyAchievements">You do not have any achievements yet!</string>
+    <string name="Trained">You trained your %s !</string>
+
+    <string name="Pushups">Push-ups</string>
+    <string name="Dips">Dips</string>
+    <string name="Burpee">Burpee</string>
+    <string name="Lunge">Lunge</string>
+    <string name="Planks">Planks</string>
+    <string name="Handstand">Handstand</string>
+    <string name="Frontlever">Front lever</string>
+    <string name="Flag">Flag</string>
+    <string name="Muscleup">Muscle-up</string>
+
 
     // Workout UI
     <string name="WorkoutDurationMessage1">I want to do %02d min and %02d seconds of %s</string>


### PR DESCRIPTION
## Overview
The objective of this Pull Request is to give to the user achievements when the training part of the app is used. With the social achievements and the medals, the progression screen now rewards all the aspect of the app.

The new achievements could be improved with the "detail" button that is currently removed. It will come back with a new associated screen in a future PR, in order to keep the size of the current PR as small as possible.

## Changes
- Add the workout ViewModel in the Progression Screen
- New achievements, base on the workout ViewModel
- The corresponding tests are updated for the new kind of achievement

## How to test

You can use the "solo training" feature of the app to train. Then, a new achievement should appear in the Progression screen, similar to the one in the screenshot below.

## Screenshot

<img width="257" alt="image" src="https://github.com/user-attachments/assets/de600eed-6ead-4b81-ab5d-ea51e1be9faa">
