### PR TITLE
Hotfix/Navigate to tutorial after sign in

### DIFF
--- a/app/src/main/java/com/android/streetworkapp/ui/authentication/SignIn.kt
+++ b/app/src/main/java/com/android/streetworkapp/ui/authentication/SignIn.kt
@@ -89,7 +89,7 @@ fun SignInScreen(
       preferencesViewModel.setName(it.username)
       preferencesViewModel.setScore(it.score)
       Toast.makeText(context, "Login successful!", Toast.LENGTH_LONG).show()
-      navigationActions.navigateTo(Screen.MAP)
+      navigationActions.navigateTo(Screen.TUTO_EVENT)
     }
   }
 


### PR DESCRIPTION
### Summary

The application tutorial was not being displayed after signing in. This pull request fixes the issue by enabling navigation to the tutorial screen after the sign-in process.

### Changes

- Updated `SignIn.kt` to include navigation to the tutorial screen upon successful sign-in.

### Testing

_Please test this fix by sign in to the application and verify that the tutorial screen is displayed immediately afterward._